### PR TITLE
Merged the two implementations.

### DIFF
--- a/src/main/java/com/togglechat/ToggleChatConfig.java
+++ b/src/main/java/com/togglechat/ToggleChatConfig.java
@@ -55,18 +55,42 @@ public interface ToggleChatConfig extends Config
 		return TabMode.ALL;
 	}
 
-	@ConfigSection(
-		position = 1,
+	@ConfigItem(
+		keyName = "removeFlashingTabs",
 		name = "Disable Notification Flash",
-		description = "For the chat-closed gamers - removes the annoying tab flashing. No blink blink"
+		description = "For the chat-closed gamers - removes the annoying tab flashing. No blink blink",
+		position = 2
+	)
+	default boolean removeFlashingTabs()
+	{
+		return false;
+	}
+
+	@ConfigSection(
+		position = 3,
+		name = "Notification Flash Settings",
+		description = "Customization for the flash settings.",
+		closedByDefault = true
 	)
 	String flashSection = "flashSection";
+
+	@ConfigItem(
+		keyName = "notifyWithOpenChat",
+		name = "Notify with chat open",
+		description = "Allows the categories to notify if chat box is opened.",
+		position = 1,
+		section = flashSection
+	)
+	default boolean notifyWithOpenChat()
+	{
+		return true;
+	}
 
 	@ConfigItem(
 		keyName = "gameChat",
 		name = "Game Chat",
 		description = "Stops game chat from flashing.",
-		position = 1,
+		position = 2,
 		section = flashSection
 	)
 	default boolean gameChat()
@@ -78,7 +102,7 @@ public interface ToggleChatConfig extends Config
 		keyName = "publicChat",
 		name = "Public Chat",
 		description = "Stops public chat from flashing.",
-		position = 2,
+		position = 3,
 		section = flashSection
 	)
 	default boolean publicChat()
@@ -90,7 +114,7 @@ public interface ToggleChatConfig extends Config
 		keyName = "privateChat",
 		name = "Private Chat",
 		description = "Stops private chat from flashing.",
-		position = 3,
+		position = 4,
 		section = flashSection
 	)
 	default boolean privateChat()
@@ -102,7 +126,7 @@ public interface ToggleChatConfig extends Config
 		keyName = "channelChat",
 		name = "Channel Chat",
 		description = "Stops channel chat from flashing.",
-		position = 4,
+		position = 5,
 		section = flashSection
 	)
 	default boolean channelChat()
@@ -114,7 +138,7 @@ public interface ToggleChatConfig extends Config
 		keyName = "clanChat",
 		name = "Clan Chat",
 		description = "Stops clan chat from flashing.",
-		position = 5,
+		position = 6,
 		section = flashSection
 	)
 	default boolean clanChat()
@@ -126,7 +150,7 @@ public interface ToggleChatConfig extends Config
 		keyName = "tradeChat",
 		name = "Trade Chat",
 		description = "Stops trade chat from flashing.",
-		position = 6,
+		position = 7,
 		section = flashSection
 	)
 	default boolean tradeChat()

--- a/src/main/java/com/togglechat/ToggleChatConfig.java
+++ b/src/main/java/com/togglechat/ToggleChatConfig.java
@@ -27,6 +27,7 @@ package com.togglechat;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Keybind;
 
 @ConfigGroup("ToggleChat")
@@ -54,14 +55,82 @@ public interface ToggleChatConfig extends Config
 		return TabMode.ALL;
 	}
 
-	@ConfigItem(
-		keyName = "removeFlashingTabs",
+	@ConfigSection(
+		position = 1,
 		name = "Disable Notification Flash",
-		description = "For the chat-closed gamers - removes the annoying tab flashing. No blink blink",
-		position = 2
+		description = "For the chat-closed gamers - removes the annoying tab flashing. No blink blink"
 	)
-	default boolean removeFlashingTabs()
+	String flashSection = "flashSection";
+
+	@ConfigItem(
+		keyName = "gameChat",
+		name = "Game Chat",
+		description = "Stops game chat from flashing.",
+		position = 1,
+		section = flashSection
+	)
+	default boolean gameChat()
 	{
-		return false;
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "publicChat",
+		name = "Public Chat",
+		description = "Stops public chat from flashing.",
+		position = 2,
+		section = flashSection
+	)
+	default boolean publicChat()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "privateChat",
+		name = "Private Chat",
+		description = "Stops private chat from flashing.",
+		position = 3,
+		section = flashSection
+	)
+	default boolean privateChat()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "channelChat",
+		name = "Channel Chat",
+		description = "Stops channel chat from flashing.",
+		position = 4,
+		section = flashSection
+	)
+	default boolean channelChat()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "clanChat",
+		name = "Clan Chat",
+		description = "Stops clan chat from flashing.",
+		position = 5,
+		section = flashSection
+	)
+	default boolean clanChat()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		keyName = "tradeChat",
+		name = "Trade Chat",
+		description = "Stops trade chat from flashing.",
+		position = 6,
+		section = flashSection
+	)
+	default boolean tradeChat()
+	{
+		return true;
 	}
 }

--- a/src/main/java/com/togglechat/ToggleChatPlugin.java
+++ b/src/main/java/com/togglechat/ToggleChatPlugin.java
@@ -29,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.VarClientStr;
 import net.runelite.api.events.ClientTick;
+import net.runelite.api.events.ScriptPreFired;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -79,17 +80,27 @@ public class ToggleChatPlugin extends Plugin implements KeyListener
 	}
 
 	@Subscribe
-	public void onClientTick(ClientTick event)
+	public void onScriptPreFired(ScriptPreFired event)
 	{
-		boolean hidden = client.getVarcIntValue(41) == 1337;
-		if (hidden && config.removeFlashingTabs())
+		if (event.getScriptId() == 179)
 		{
-			client.setVarcIntValue(44, 0);
-			client.setVarcIntValue(45, 0);
-			client.setVarcIntValue(46, 0);
-			client.setVarcIntValue(438, 0);
-			client.setVarcIntValue(47, 0);
-			client.setVarcIntValue(48, 0);
+			if (config.gameChat())
+				client.setVarcIntValue(44, 0);
+
+			if (config.publicChat())
+				client.setVarcIntValue(45, 0);
+
+			if (config.privateChat())
+				client.setVarcIntValue(46, 0);
+
+			if (config.clanChat())
+				client.setVarcIntValue(47, 0);
+
+			if (config.tradeChat())
+				client.setVarcIntValue(48, 0);
+
+			if (config.channelChat())
+				client.setVarcIntValue(438, 0);
 		}
 	}
 

--- a/src/main/java/com/togglechat/ToggleChatPlugin.java
+++ b/src/main/java/com/togglechat/ToggleChatPlugin.java
@@ -84,6 +84,16 @@ public class ToggleChatPlugin extends Plugin implements KeyListener
 	{
 		if (event.getScriptId() == 179)
 		{
+			// If the user does not want to disable flashing.
+			if(!config.removeFlashingTabs())
+				return;
+
+			// Allows notifications to appear in chat if the chat box is open.
+			boolean hidden = client.getVarcIntValue(41) == 1337;
+			if(config.notifyWithOpenChat() && !hidden)
+				return;
+
+			// Disables the flashing of specified chats.
 			if (config.gameChat())
 				client.setVarcIntValue(44, 0);
 


### PR DESCRIPTION
I added some features from my version of "No Chat Flash".
I noticed that your version used onClientTick to stop the flashing. When I was also creating this feature Adam showed me the onScriptPrefire which allowed me to clear the flashing on new messages received. 
This difference means that it will not immediately clear previously solid blue channels but after the channels have been reset they will not flash again. They will also clear if a new message is received before the notification is manually cleared.
I also added some configurations to specify which channels to stop flashing.

I attempted to keep the functionality of the plugin identical to how you had originally implemented it, while adding the features from mine.