### PR TITLE
fix(herb-timers): updated herb timers to new time.

### DIFF
--- a/src/main/java/com/coxadditions/CoxAdditionsPlugin.java
+++ b/src/main/java/com/coxadditions/CoxAdditionsPlugin.java
@@ -413,9 +413,9 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 		playersInParty.clear();
 
 		coxHerb1 = null;
-		coxHerbTimer1 = 16;
+		coxHerbTimer1 = 11;
 		coxHerb2 = null;
-		coxHerbTimer2 = 16;
+		coxHerbTimer2 = 11;
 
 		totalBuchus = 0;
 		totalGolpar = 0;
@@ -912,12 +912,12 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 				if (coxHerb1 == null)
 				{
 					coxHerb1 = obj;
-					coxHerbTimer1 = 16;
+					coxHerbTimer1 = 11;
 				}
 				else
 				{
 					coxHerb2 = obj;
-					coxHerbTimer2 = 16;
+					coxHerbTimer2 = 11;
 				}
 			}
 			else if (obj.getId() >= 30000 && obj.getId() <= 30008)
@@ -925,12 +925,12 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 				if (coxHerb1 == null)
 				{
 					coxHerb1 = obj;
-					coxHerbTimer1 = 16;
+					coxHerbTimer1 = 11;
 				}
 				else
 				{
 					coxHerb2 = obj;
-					coxHerbTimer2 = 16;
+					coxHerbTimer2 = 11;
 				}
 			}
 			else if (obj.getId() == 29745) //Chest with Grubs
@@ -1460,9 +1460,9 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 			smallMutta = null;
 
 			coxHerb1 = null;
-			coxHerbTimer1 = 16;
+			coxHerbTimer1 = 11;
 			coxHerb2 = null;
-			coxHerbTimer2 = 16;
+			coxHerbTimer2 = 11;
 
 			totalBuchus = 0;
 			totalGolpar = 0;

--- a/src/main/java/com/coxadditions/overlay/CoxAdditionsOverlay.java
+++ b/src/main/java/com/coxadditions/overlay/CoxAdditionsOverlay.java
@@ -114,8 +114,8 @@ public class CoxAdditionsOverlay extends Overlay
 						progressPie.setFill(colorFill);
 						progressPie.setBorderColor(config.coxHerbTimerColor());
 						progressPie.setPosition(position);
-						int ticks = 16 - plugin.getCoxHerbTimer1();
-						double progress = 1 - (ticks / 16.0);
+						int ticks = 11 - plugin.getCoxHerbTimer1();
+						double progress = 1 - (ticks / 11.0);
 						progressPie.setProgress(progress);
 						progressPie.render(graphics);
 					}
@@ -129,8 +129,8 @@ public class CoxAdditionsOverlay extends Overlay
 						progressPie.setFill(colorFill);
 						progressPie.setBorderColor(config.coxHerbTimerColor());
 						progressPie.setPosition(position);
-						int ticks = 16 - plugin.getCoxHerbTimer2();
-						double progress = 1 - (ticks / 16.0);
+						int ticks = 11 - plugin.getCoxHerbTimer2();
+						double progress = 1 - (ticks / 11.0);
 						progressPie.setProgress(progress);
 						progressPie.render(graphics);
 					}


### PR DESCRIPTION
Back in November, Jagex updated the growth time of herbs in cox. This PR should update the plugin to use the new time for herbs, updated from 16 ticks to 11 ticks.