### PR TITLE
Fix bone dagger and crossbow

### DIFF
--- a/src/main/java/com/partydefencetracker/DefenceTrackerPlugin.java
+++ b/src/main/java/com/partydefencetracker/DefenceTrackerPlugin.java
@@ -606,7 +606,10 @@ public class DefenceTrackerPlugin extends Plugin
 				break;
 			case BONE_DAGGER:
 			case DORGESHUUN_CROSSBOW:
-				bossDef -= hit;
+				if (bossDef >= BossInfo.getBaseDefence(boss))
+				{
+					bossDef -= hit;
+				}
 				break;
 			case ACCURSED_SCEPTRE:
 				if (hit > 0)


### PR DESCRIPTION
Both bone dagger and crossbow only lower the targets defence if the defence level isn't currently trained. Verified with monster examine and by asking mod Ash on [twitter](https://x.com/JagexAsh/status/1798626951885889739). ([archived tweet](https://archive.ph/tsLWH))