### PR TITLE
Updated README for pluginhub.info shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # CoX Additions
 
-[![Plugin Installs](https://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/installs/plugin/cox-qol)](https://runelite.net/plugin-hub/TheStonedTurtle) 
+[![Plugin Installs](https://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/installs/plugin/cox-qol)](https://runelite.net/plugin-hub/TheStonedTurtle) 
 
-[![Plugin Rank](http://img.shields.io/endpoint?url=https://i.pluginhub.info/shields/rank/plugin/cox-qol)](https://runelite.net/plugin-hub)
+[![Plugin Rank](http://img.shields.io/endpoint?url=https://api.runelite.net/pluginhub/shields/rank/plugin/cox-qol)](https://runelite.net/plugin-hub)
 
 Additional QOL features for CoX.
 


### PR DESCRIPTION
The website [i.pluginhub.info](https://i.pluginhub.info), which powers your README badges, is going to be shut down at the end of the month (November 1st, 2024) as you can now use RuneLite's API to generate these shields (as was done in this PR).

I highly recommend you merge this PR, or make this change yourself, before the shutdown date to avoid your badges breaking.

You should also create a PR to the hub so that your readme updates on [RuneLite.net's Plugin Hub](https://runelite.net/plugin-hub/show/cox-additions) website after merging this PR, but that's up to you

Anyway, thanks for using my website while it was alive :heart: