### PR TITLE
Add Shadow Sceptre tracking

### DIFF
--- a/src/main/java/com/partydefencetracker/DefenceTrackerConfig.java
+++ b/src/main/java/com/partydefencetracker/DefenceTrackerConfig.java
@@ -99,10 +99,18 @@ public interface DefenceTrackerConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "shadowBarrage",
+			name = "Show Shadow Barrage",
+			description = "Displays an infobox when you successfully land a shadow barrage whilst wearing the shadow ancient sceptre",
+			position = 7
+	)
+	default boolean shadowBarrage() { return true; }
+
+	@ConfigItem(
 		keyName = "redKeris",
 		name = "Show Red Keris",
 		description = "Displays an infobox when you successfully land a Red Keris (Corruption) special attack",
-		position = 7
+		position = 8
 	)
 	default boolean redKeris()
 	{

--- a/src/main/java/com/partydefencetracker/ShadowBarrageInfoBox.java
+++ b/src/main/java/com/partydefencetracker/ShadowBarrageInfoBox.java
@@ -1,0 +1,27 @@
+package com.partydefencetracker;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+
+import net.runelite.client.ui.overlay.infobox.InfoBox;
+
+public class ShadowBarrageInfoBox extends InfoBox
+{
+    private DefenceTrackerPlugin plugin;
+
+    ShadowBarrageInfoBox(BufferedImage image, DefenceTrackerPlugin plugin)
+    {
+        super(image, plugin);
+        this.plugin = plugin;
+    }
+
+    public String getText()
+    {
+        return null;
+    }
+
+    public Color getTextColor()
+    {
+        return Color.WHITE;
+    }
+}


### PR DESCRIPTION
Added tracking for shadow barrage with the shadow sceptre.

Added params to ensure shadow barrage is a one-time reduction.

Added ashadow sceptre infobox, similar to vulernability (except the icon is the sceptre, because the barrage was ugly).

Refactored some of the onGraphicChanged methods to be a bit cleaner given there are two possible outcomes here.