### PR TITLE
shadowbarrage: correct defence reduction

### DIFF
--- a/src/main/java/com/partydefencetracker/DefenceTrackerPlugin.java
+++ b/src/main/java/com/partydefencetracker/DefenceTrackerPlugin.java
@@ -463,7 +463,7 @@ public class DefenceTrackerPlugin extends Plugin
 							infoBoxManager.addInfoBox(shadowBarrageBox);
 						}
 						shadowBarrageHit = true; // non-stackable reduction
-						bossDef -= bossDef * .15;
+						bossDef -= bossDef * .165;
 
 						updateDefInfobox();
 					}


### PR DESCRIPTION
Shadow Barrage when using Shadow Ancient Sceptre reduces 16.5%

This is 10% on top of the base 15% reduction. Confirmed via monster examine.