### PR TITLE
Fix error when editing npc ids and

### DIFF
--- a/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
+++ b/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
@@ -873,7 +873,7 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 			&& client.getLocalPlayer().getPlayerComposition() != null)
 		{
 			npcList.clear();
-			for (NPC npc : client.getTopLevelWorldView().npcs())
+			for (NPC npc : client.getTopLevelWorldView().npcs().stream().collect(Collectors.toCollection(ArrayList::new)))
 			{
 				NPCInfo npcInfo = checkValidNPC(npc);
 				if (npcInfo != null)


### PR DESCRIPTION
enabling the addon when any npcs are in the current worldview.

I did not test this. I don't have a runelite development environment set up. I just looked at the recent changes that were made and used the code from the old getNpcs() function that has now been deprecated. There may be a more elegant solution, I'm just not a java developer.

Code I referenced can be found at 

https://github.com/runelite/runelite/blob/17591cb3b3fe381b454a202e22f5e4e74d3fea72/runelite-api/src/main/java/net/runelite/api/Client.java#L2202