### PR TITLE
Fix error from editing ids and enabling addin while logged in

### DIFF
--- a/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
+++ b/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
@@ -922,9 +922,9 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 			}
 		}
 
-		if (npc.getName() != null)
+		if (npc.getComposition().getName() != null)
 		{
-			String name = npc.getName().toLowerCase();
+			String name = npc.getComposition().getName().toLowerCase();
 			for (String entry : strList)
 			{
 				String nameStr = entry;
@@ -947,9 +947,9 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 
 	public boolean checkSpecificNameList(ArrayList<String> strList, NPC npc)
 	{
-		if (npc.getName() != null)
+		if (npc.getComposition().getName() != null)
 		{
-			String name = npc.getName().toLowerCase();
+			String name = npc.getComposition().getName().toLowerCase();
 			for (String entry : strList)
 			{
 				String nameStr = entry;


### PR DESCRIPTION
This solves the issues from disabling and enabling the plugin while logged in. I have tested it and it works correctly.

I'm not sure what the difference is between npc.getName() and npc.getComposition().getName() but they appeared to return the same value in all the cases I tested. The only exception I found was when npc.getName() threw an error, when npc.getName() throws the error, npc.getComposition().getName() returns the correct name.

The error in question is below and it occurs when enabling the plugin and when editing various "plugin configuration" options in the side panel while logged in and NPCs are visible.

```
java.lang.IllegalStateException: must be called on client thread
	at ew.zg(ew.java:32569)
	at ew.getName(ew.java:45251)
	at com.betternpchighlight.BetterNpcHighlightPlugin.checkSpecificList(BetterNpcHighlightPlugin.java:925)
	at com.betternpchighlight.NPCInfo.<init>(NPCInfo.java:28)
	at com.betternpchighlight.BetterNpcHighlightPlugin.checkValidNPC(BetterNpcHighlightPlugin.java:890)
	at com.betternpchighlight.BetterNpcHighlightPlugin.recreateList(BetterNpcHighlightPlugin.java:878)
	at com.betternpchighlight.BetterNpcHighlightPlugin.onConfigChanged(BetterNpcHighlightPlugin.java:322)
```