### PR TITLE
Update incorrect shadow barrage reduction; remove the shadow barrage infobox after Sotetseg phases.

### DIFF
--- a/src/main/java/com/partydefencetracker/DefenceTrackerPlugin.java
+++ b/src/main/java/com/partydefencetracker/DefenceTrackerPlugin.java
@@ -238,6 +238,8 @@ public class DefenceTrackerPlugin extends Plugin
 				if (animation == 1816 && boss.equalsIgnoreCase("sotetseg") && inBossRegion())
 				{
 					infoBoxManager.removeInfoBox(box);
+					infoBoxManager.removeInfoBox(shadowBarrageBox);
+					shadowBarrageHit = false;
 					bossDef = 200;
 				}
 			}
@@ -461,7 +463,7 @@ public class DefenceTrackerPlugin extends Plugin
 							infoBoxManager.addInfoBox(shadowBarrageBox);
 						}
 						shadowBarrageHit = true; // non-stackable reduction
-						bossDef -= bossDef * .15;
+						bossDef -= bossDef * .165;
 
 						updateDefInfobox();
 					}

--- a/src/main/java/com/partydefencetracker/DefenceTrackerPlugin.java
+++ b/src/main/java/com/partydefencetracker/DefenceTrackerPlugin.java
@@ -79,6 +79,7 @@ import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.Text;
+import org.apache.commons.lang3.ObjectUtils;
 
 @PluginDescriptor(
 	name = "Party Defence Tracker",
@@ -131,7 +132,6 @@ public class DefenceTrackerPlugin extends Plugin
 	private VulnerabilityInfoBox vulnBox = null;
 	private SpritePixels vuln = null;
 	private ShadowBarrageInfoBox shadowBarrageBox = null;
-	private SpritePixels shadowBarrage = null;
 	private boolean shadowBarrageHit = false;
 
 	private RedKerisInfoBox redKerisBox = null;
@@ -218,7 +218,6 @@ public class DefenceTrackerPlugin extends Plugin
 		redKerisBox = null;
 		redKerisTicks = 0;
 		shadowBarrageBox = null;
-		shadowBarrage = null;
 		shadowBarrageHit = false;
 		bloatDown = false;
 		queuedNpc = null;
@@ -306,7 +305,7 @@ public class DefenceTrackerPlugin extends Plugin
 		specialList.clear();
 		if (partyService.isInParty())
 		{
-			for (NPC n : client.getNpcs())
+			for (NPC n : client.getTopLevelWorldView().npcs())
 			{
 				if (n != null && n.getName() != null && (n.getName().equalsIgnoreCase(boss) || (n.getName().contains("Tekton") && boss.equalsIgnoreCase("Tekton")))
 					&& (n.isDead() || n.getHealthRatio() == 0))


### PR DESCRIPTION
Shadow barrage has been tested to have 16.5% defence reduction, not 15%.
Remove the Sotetseg shadow barrage infobox after phasing. Additionally, reset the Shadow Barrage hit flag, as once the phase swaps, shadow barrage can lower defence again. 