### PR TITLE
Allow for multiple tag styles when tagging npc

### DIFF
--- a/src/main/java/com/betternpchighlight/BetterNpcHighlightConfig.java
+++ b/src/main/java/com/betternpchighlight/BetterNpcHighlightConfig.java
@@ -1610,10 +1610,10 @@ public interface BetterNpcHighlightConfig extends Config
 	// No Section
 	//------------------------------------------------------------//
 	@ConfigItem(
-	position = 13,
-	keyName = "tagStyleMode",
-	name = "Tag Style",
-	description = "Sets which highlight style(s) the NPC tagged is added too"
+		position = 13,
+		keyName = "tagStyleMode",
+		name = "Tag Style",
+		description = "Sets which highlight style(s) the NPC tagged is added too"
 	)
 	default Set<tagStyleMode> tagStyleMode()
 	{

--- a/src/main/java/com/betternpchighlight/BetterNpcHighlightConfig.java
+++ b/src/main/java/com/betternpchighlight/BetterNpcHighlightConfig.java
@@ -1610,13 +1610,14 @@ public interface BetterNpcHighlightConfig extends Config
 	// No Section
 	//------------------------------------------------------------//
 	@ConfigItem(
-		position = 13,
-		keyName = "tagStyleMode",
-		name = "Tag Style",
-		description = "Sets which highlight style list the NPC tagged is added too")
-	default tagStyleMode tagStyleMode()
+	position = 13,
+	keyName = "tagStyleMode",
+	name = "Tag Style",
+	description = "Sets which highlight style(s) the NPC tagged is added too"
+	)
+	default Set<tagStyleMode> tagStyleMode()
 	{
-		return tagStyleMode.TILE;
+		return Collections.emptySet();
 	}
 
 	@ConfigItem(

--- a/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
+++ b/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
@@ -727,35 +727,35 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 		{
 			config.setTileNames(configListToString(add, name, tileNames, preset));
 		}
-		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE))
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE))
 		{
 			config.setTrueTileNames(configListToString(add, name, trueTileNames, preset));
 		}
-		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TILE))
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TILE))
 		{
 			config.setSwTileNames(configListToString(add, name, swTileNames, preset));
 		}
-		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE))
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE))
 		{
 			config.setSwTrueTileNames(configListToString(add, name, swTrueTileNames, preset));
 		}
-		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.HULL))
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.HULL))
 		{
 			config.setHullNames(configListToString(add, name, hullNames, preset));
 		}
-		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.AREA))
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.AREA))
 		{
 			config.setAreaNames(configListToString(add, name, areaNames, preset));
 		}
-		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.OUTLINE))
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.OUTLINE))
 		{
 			config.setOutlineNames(configListToString(add, name, outlineNames, preset));
 		}
-		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.CLICKBOX))
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.CLICKBOX))
 		{
 			config.setClickboxNames(configListToString(add, name, clickboxNames, preset));
 		}
-		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TURBO))
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TURBO))
 		{
 			config.setTurboNames(configListToString(add, name, turboNames, 0));
 		}

--- a/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
+++ b/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
@@ -498,37 +498,54 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 			if (npc != null)
 			{
 				String option;
-				if (npc.getName() != null && config.tagStyleMode() != BetterNpcHighlightConfig.tagStyleMode.NONE)
+				if (npc.getName() != null && !config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.NONE) && !config.tagStyleMode().isEmpty())
 				{
-					if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.TILE)
+					// if (checkSpecificNameList(tileNames, npc) ||
+					// 		checkSpecificNameList(trueTileNames, npc) ||
+					// 		checkSpecificNameList(swTileNames, npc) ||
+					// 		checkSpecificNameList(swTrueTileNames, npc) ||
+					// 		checkSpecificNameList(hullNames, npc) ||
+					// 		checkSpecificNameList(areaNames, npc) ||
+					// 		checkSpecificNameList(outlineNames, npc) ||
+					// 		checkSpecificNameList(clickboxNames, npc) ||
+					// 		checkSpecificNameList(turboNames, npc))
+					// {
+					// 	option = "Untag";
+					// }
+					// else
+					// {
+					// 	option = "Tag";
+					// }
+
+					if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TILE))
 					{
 						option = checkSpecificNameList(tileNames, npc) ? "Untag-Tile" : "Tag-Tile";
 					}
-					else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE)
+					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE))
 					{
 						option = checkSpecificNameList(trueTileNames, npc) ? "Untag-True-Tile" : "Tag-True-Tile";
 					}
-					else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.SW_TILE)
+					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TILE))
 					{
 						option = checkSpecificNameList(swTileNames, npc) ? "Untag-SW-Tile" : "Tag-SW-Tile";
 					}
-					else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE)
+					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE))
 					{
 						option = checkSpecificNameList(swTrueTileNames, npc) ? "Untag-SW-True-Tile" : "Tag-SW-True-Tile";
 					}
-					else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.HULL)
+					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.HULL))
 					{
 						option = checkSpecificNameList(hullNames, npc) ? "Untag-Hull" : "Tag-Hull";
 					}
-					else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.AREA)
+					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.AREA))
 					{
 						option = checkSpecificNameList(areaNames, npc) ? "Untag-Area" : "Tag-Area";
 					}
-					else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.OUTLINE)
+					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.OUTLINE))
 					{
 						option = checkSpecificNameList(outlineNames, npc) ? "Untag-Outline" : "Tag-Outline";
 					}
-					else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.CLICKBOX)
+					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.CLICKBOX))
 					{
 						option = checkSpecificNameList(clickboxNames, npc) ? "Untag-Clickbox" : "Tag-Clickbox";
 					}
@@ -542,7 +559,7 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 						MenuEntry[] menuEntries = client.getMenuEntries();
 						final MenuEntry menuEntry = menuEntries[menuEntries.length - 1];
 						String target;
-						if (option.contains("Turbo"))
+						if (checkSpecificNameList(turboNames, npc))
 						{
 							target = ColorUtil.prependColorTag(Text.removeTags(event.getTarget()), Color.getHSBColor(new Random().nextFloat(), 1.0F, 1.0F));
 						}
@@ -561,7 +578,7 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 						if (config.highlightMenuNames() || (npc.isDead() && config.deadNpcMenuColor() != null))
 						{
 							String colorCode;
-							if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.TURBO)
+							if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TURBO))
 							{
 								if (turboColors.size() == 0 && turboNames.contains(npc.getName().toLowerCase()))
 								{
@@ -706,39 +723,39 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 
 	private void updateListConfig(boolean add, String name, int preset)
 	{
-		if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.TILE)
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TILE))
 		{
 			config.setTileNames(configListToString(add, name, tileNames, preset));
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE))
 		{
 			config.setTrueTileNames(configListToString(add, name, trueTileNames, preset));
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.SW_TILE)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TILE))
 		{
 			config.setSwTileNames(configListToString(add, name, swTileNames, preset));
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE))
 		{
 			config.setSwTrueTileNames(configListToString(add, name, swTrueTileNames, preset));
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.HULL)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.HULL))
 		{
 			config.setHullNames(configListToString(add, name, hullNames, preset));
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.AREA)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.AREA))
 		{
 			config.setAreaNames(configListToString(add, name, areaNames, preset));
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.OUTLINE)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.OUTLINE))
 		{
 			config.setOutlineNames(configListToString(add, name, outlineNames, preset));
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.CLICKBOX)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.CLICKBOX))
 		{
 			config.setClickboxNames(configListToString(add, name, clickboxNames, preset));
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.TURBO)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TURBO))
 		{
 			config.setTurboNames(configListToString(add, name, turboNames, 0));
 		}
@@ -1012,35 +1029,35 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 	 */
 	public Color getTagColor()
 	{
-		if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.TILE)
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TILE))
 		{
 			return config.tileColor();
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE))
 		{
 			return config.trueTileColor();
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.SW_TILE)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TILE))
 		{
 			return config.swTileColor();
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE))
 		{
 			return config.swTrueTileColor();
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.HULL)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.HULL))
 		{
 			return config.hullColor();
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.AREA)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.AREA))
 		{
 			return config.areaColor();
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.OUTLINE)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.OUTLINE))
 		{
 			return config.outlineColor();
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.CLICKBOX)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.CLICKBOX))
 		{
 			return config.clickboxColor();
 		}


### PR DESCRIPTION
I wanted the ability to tag a NPC for multiple tag types at once. For example if I right click a mob and click tag-tile, I also want it to tag the true tile and SW tile at the same time.

![image](https://github.com/user-attachments/assets/e1190f9e-7318-46d5-945b-531ff515cd42)

To achieve this I modified the tag style config to use a list of options like the slayer highlight list does already.

There are some inconsistencies that I still need to iron out, but I wanted to get a conversation going to make sure this is a feature that would be accepted before I sink any more time into it.

Known issues:
- If you have 2 tag types selected, tag a npc, deselect 1 of those tag types, then untag the npc, the unselected type will not untag
- There are some inconsistencies with menu color when the `highlight menu names` option is enabled. The code that chooses what color to make the menu entry needs a refactor to work with this. Either by defining a static color, or by allowing it to use a top to bottom priority on what color to make it. The biggest problem right now is that it defaults to a random color when no tag style is selected. The second problem is that theres no real consistency in what color it selects between preset colors and different tag style colors, depending on the tag style(s) selected.