### PR TITLE
[party defence tracker] add yama and emberlight spec tracking

### DIFF
--- a/src/main/java/com/partydefencetracker/BossInfo.java
+++ b/src/main/java/com/partydefencetracker/BossInfo.java
@@ -58,6 +58,7 @@ enum BossInfo
 	VETION("Vet'ion", 395, 300),
 	VORKATH("Vorkath", 214, 150),
 	XARPUS("Xarpus", 250, 220),
+	YAMA("Yama", 225, 250),
 	ZEBAK("Zebak", 20, 100),
 	ZULRAH("Zulrah", 300, 300);
 

--- a/src/main/java/com/partydefencetracker/DefenceTrackerPlugin.java
+++ b/src/main/java/com/partydefencetracker/DefenceTrackerPlugin.java
@@ -684,6 +684,19 @@ public class DefenceTrackerPlugin extends Plugin
 					}
 				}
 				break;
+			case EMBERLIGHT:
+				if (hit > 0)
+				{
+					if (boss.equalsIgnoreCase("K'ril Tsutsaroth") || boss.equalsIgnoreCase("Abyssal Sire") || boss.equalsIgnoreCase("Yama"))
+					{
+						bossDef -= BossInfo.getBaseDefence(boss) * .15;
+					}
+					else
+					{
+						bossDef -= BossInfo.getBaseDefence(boss) * .05;
+					}
+				}
+				break;
 			case BARRELCHEST_ANCHOR:
 				bossDef -= hit * .10;
 				break;

--- a/src/main/java/com/partydefencetracker/DefenceTrackerPlugin.java
+++ b/src/main/java/com/partydefencetracker/DefenceTrackerPlugin.java
@@ -181,6 +181,7 @@ public class DefenceTrackerPlugin extends Plugin
 		put("TzKal-Zuk", new ArrayList<>(Collections.singletonList(9043)));
 		put("TzTok-Jad", new ArrayList<>(Collections.singletonList(9551)));
 		put("Vorkath", new ArrayList<>(Collections.singletonList(9023)));
+		put("Yama", new ArrayList<>(Collections.singletonList(6045)));
 		put("Zulrah", new ArrayList<>(Arrays.asList(9007, 9008)));
 	}};
 

--- a/src/main/java/com/partydefencetracker/DefenceTrackerPlugin.java
+++ b/src/main/java/com/partydefencetracker/DefenceTrackerPlugin.java
@@ -715,6 +715,10 @@ public class DefenceTrackerPlugin extends Plugin
 		{
 			bossDef = 100;
 		}
+		else if (boss.equalsIgnoreCase("Yama") && bossDef < 145)
+		{
+			bossDef = 145;
+		}
 		else if (bossDef < 0)
 		{
 			bossDef = 0;

--- a/src/main/java/com/partydefencetracker/DefenceTrackerPlugin.java
+++ b/src/main/java/com/partydefencetracker/DefenceTrackerPlugin.java
@@ -674,7 +674,7 @@ public class DefenceTrackerPlugin extends Plugin
 			case DARKLIGHT:
 				if (hit > 0)
 				{
-					if (boss.equalsIgnoreCase("K'ril Tsutsaroth") || boss.equalsIgnoreCase("Abyssal Sire"))
+					if (boss.equalsIgnoreCase("K'ril Tsutsaroth") || boss.equalsIgnoreCase("Abyssal Sire") || boss.equalsIgnoreCase("Yama"))
 					{
 						bossDef -= BossInfo.getBaseDefence(boss) * .10;
 					}


### PR DESCRIPTION
This PR adds Yama and Emberlight spec tracking to the Party Defence Tracker plugin.

Was wondering if I should've done 80 for the defence info as that's the drain cap and it would show 0 like the TOA bosses. But, it looks like using Elder Maul and Emberlight is popular here so I figured it'd be better to use the actual defence level and add handling for the cap like Sotetseg.