### PR TITLE
Add multiple tag styles when tagging npc, global tag color option

### DIFF
--- a/src/main/java/com/betternpchighlight/BetterNpcHighlightConfig.java
+++ b/src/main/java/com/betternpchighlight/BetterNpcHighlightConfig.java
@@ -1610,10 +1610,10 @@ public interface BetterNpcHighlightConfig extends Config
 	// No Section
 	//------------------------------------------------------------//
 	@ConfigItem(
-	position = 13,
-	keyName = "tagStyleMode",
-	name = "Tag Style",
-	description = "Sets which highlight style(s) the NPC tagged is added too"
+		position = 13,
+		keyName = "tagStyleMode",
+		name = "Tag Style",
+		description = "Sets which highlight style(s) the NPC tagged is added too"
 	)
 	default Set<tagStyleMode> tagStyleMode()
 	{

--- a/src/main/java/com/betternpchighlight/BetterNpcHighlightConfig.java
+++ b/src/main/java/com/betternpchighlight/BetterNpcHighlightConfig.java
@@ -1610,13 +1610,14 @@ public interface BetterNpcHighlightConfig extends Config
 	// No Section
 	//------------------------------------------------------------//
 	@ConfigItem(
-		position = 13,
-		keyName = "tagStyleMode",
-		name = "Tag Style",
-		description = "Sets which highlight style list the NPC tagged is added too")
-	default tagStyleMode tagStyleMode()
+	position = 13,
+	keyName = "tagStyleMode",
+	name = "Tag Style",
+	description = "Sets which highlight style(s) the NPC tagged is added too"
+	)
+	default Set<tagStyleMode> tagStyleMode()
 	{
-		return tagStyleMode.TILE;
+		return Collections.emptySet();
 	}
 
 	@ConfigItem(

--- a/src/main/java/com/betternpchighlight/BetterNpcHighlightConfig.java
+++ b/src/main/java/com/betternpchighlight/BetterNpcHighlightConfig.java
@@ -1655,19 +1655,6 @@ public interface BetterNpcHighlightConfig extends Config
 		return new Color(0, 255, 255, 20);
 	}
 
-	@Range(min = 0, max = 50)
-	@ConfigItem(
-		position = 3,
-		keyName = "globaltileWidth",
-		name = "Global Highlight Width",
-		description = "Overrides all other tag style highlight widths.",
-		section = globalTagSection
-	)
-	default double globaltileWidth()
-	{
-		return 2;
-	}
-
 	//------------------------------------------------------------//
 	// No Section
 	//------------------------------------------------------------//

--- a/src/main/java/com/betternpchighlight/BetterNpcHighlightConfig.java
+++ b/src/main/java/com/betternpchighlight/BetterNpcHighlightConfig.java
@@ -142,6 +142,14 @@ public interface BetterNpcHighlightConfig extends Config
 	)
 	String instructionsSection = "instructions";
 
+	@ConfigSection(
+		name = "Global Tag Style",
+		description = "Options for a global tag style",
+		position = 13,
+		closedByDefault = true
+	)
+	String globalTagSection = "globalTagStyle";
+
 	//------------------------------------------------------------//
 	// Tile Section
 	//------------------------------------------------------------//
@@ -1607,10 +1615,64 @@ public interface BetterNpcHighlightConfig extends Config
 	}
 
 	//------------------------------------------------------------//
+	// Global tag style section
+	//------------------------------------------------------------//
+	@ConfigItem(
+		position = 0,
+		keyName = "useGlobalTileColor",
+		name = "Use Global Tile Color",
+		description = "Makes all tile types use the options below instead of individual by tile type. Will not override tiles using a preset. Will not override types hull, area, outline, clickbox, or turbo.",
+		section = globalTagSection
+	)
+	default boolean useGlobalTileColor()
+	{
+		return false;
+	}
+
+	@Alpha
+	@ConfigItem(
+		position = 1,
+		keyName = "globalTileColor",
+		name = "Global Tile Color",
+		description = "Overrides all other tag style outlines.",
+		section = globalTagSection
+	)
+	default Color globalTileColor()
+	{
+		return Color.CYAN;
+	}
+
+	@Alpha
+	@ConfigItem(
+		position = 2,
+		keyName = "globalFillColor",
+		name = "Global Fill Color",
+		description = "Overrides all other tag style fill colors.",
+		section = globalTagSection
+	)
+	default Color globalFillColor()
+	{
+		return new Color(0, 255, 255, 20);
+	}
+
+	@Range(min = 0, max = 50)
+	@ConfigItem(
+		position = 3,
+		keyName = "globaltileWidth",
+		name = "Global Highlight Width",
+		description = "Overrides all other tag style highlight widths.",
+		section = globalTagSection
+	)
+	default double globaltileWidth()
+	{
+		return 2;
+	}
+
+	//------------------------------------------------------------//
 	// No Section
 	//------------------------------------------------------------//
 	@ConfigItem(
-		position = 13,
+		position = 14,
 		keyName = "tagStyleMode",
 		name = "Tag Style",
 		description = "Sets which highlight style(s) the NPC tagged is added too"
@@ -1621,7 +1683,7 @@ public interface BetterNpcHighlightConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 14,
+		position = 15,
 		keyName = "tagCommands",
 		name = "Tag Commands",
 		description = "Enables the use of commands to add/remove NPCs to the Names/IDs list <br>Read the guide in Instructions section"
@@ -1632,7 +1694,7 @@ public interface BetterNpcHighlightConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 15,
+		position = 16,
 		keyName = "highlightMenuNames",
 		name = "Highlight Menu Names",
 		description = "Highlights names in right click menu entry"
@@ -1643,7 +1705,7 @@ public interface BetterNpcHighlightConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 16,
+		position = 17,
 		keyName = "ignoreDeadNpcs",
 		name = "Ignore Dead NPCs",
 		description = "Doesn't highlight dead NPCs"
@@ -1654,7 +1716,7 @@ public interface BetterNpcHighlightConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 17,
+		position = 18,
 		keyName = "ignoreDeadExclusion",
 		name = "Ignore Dead Exclusion Name List",
 		description = "List of NPC names to not remove highlight when dead"
@@ -1665,7 +1727,7 @@ public interface BetterNpcHighlightConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 18,
+		position = 19,
 		keyName = "ignoreDeadExclusionID",
 		name = "Ignore Dead Exclusion ID List",
 		description = "List of NPC IDs to not remove highlight when dead"
@@ -1676,7 +1738,7 @@ public interface BetterNpcHighlightConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 19,
+		position = 20,
 		keyName = "drawBeneath",
 		name = "Draw Overlays Beneath NPCs",
 		description = "Overlays will appear behind/below NPCs. GPU plugin must be turned on"
@@ -1688,7 +1750,7 @@ public interface BetterNpcHighlightConfig extends Config
 
 	@Range(max = 20)
 	@ConfigItem(
-		position = 20,
+		position = 21,
 		keyName = "drawBeneathLimit",
 		name = "Draw Beneath Limit",
 		description = "Sets the amount of NPCs to have the overlay draw beneath. The higher the number, the more it affects FPS"
@@ -1699,7 +1761,7 @@ public interface BetterNpcHighlightConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 21,
+		position = 22,
 		keyName = "drawBeneathList",
 		name = "Draw Beneath List",
 		description = "Sets specific NPCs to have the overlay draw beneath. Empty list will use Draw Beneath Limit"
@@ -1710,7 +1772,7 @@ public interface BetterNpcHighlightConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 22,
+		position = 23,
 		keyName = "renderDistance",
 		name = "Render Distance",
 		description = "Limits overlays to be drawn to within the chosen distance from the local player. <br>Short = 7 tiles, Medium = 11 tiles"
@@ -1721,7 +1783,7 @@ public interface BetterNpcHighlightConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 23,
+		position = 24,
 		keyName = "highlightPets",
 		name = "Highlight pets",
 		description = "Highlights followers/pets that are in any of your lists"
@@ -1732,7 +1794,7 @@ public interface BetterNpcHighlightConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 24,
+		position = 25,
 		keyName = "deadNpcMenuColor",
 		name = "Dead NPC Menu Color",
 		description = "Highlights names in right click menu entry when an NPC is dead"
@@ -1740,7 +1802,7 @@ public interface BetterNpcHighlightConfig extends Config
 	Color deadNpcMenuColor();
 
 	@ConfigItem(
-		position = 25,
+		position = 26,
 		keyName = "respawnTimer",
 		name = "Respawn Timer",
 		description = "Marks tile and shows timer for when a marker NPC will respawn"
@@ -1752,7 +1814,7 @@ public interface BetterNpcHighlightConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-		position = 26,
+		position = 27,
 		keyName = "respawnTimerColor",
 		name = "Respawn Time Color",
 		description = "Sets the color of the text for Respawn Timer"
@@ -1764,7 +1826,7 @@ public interface BetterNpcHighlightConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-		position = 27,
+		position = 28,
 		keyName = "respawnOutlineColor",
 		name = "Respawn Outline Color",
 		description = "Sets the color of the tile for Respawn Timer"
@@ -1776,7 +1838,7 @@ public interface BetterNpcHighlightConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-		position = 28,
+		position = 29,
 		keyName = "respawnFillColor",
 		name = "Respawn Fill Color",
 		description = "Sets the fill color of the tile for Respawn Timer"
@@ -1788,7 +1850,7 @@ public interface BetterNpcHighlightConfig extends Config
 
 	@Range(min = 1, max = 10)
 	@ConfigItem(
-		position = 29,
+		position = 30,
 		keyName = "respawnTileWidth",
 		name = "Respawn Tile Width",
 		description = "Sets the width of the tile for Respawn Timer"
@@ -1799,7 +1861,7 @@ public interface BetterNpcHighlightConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 30,
+		position = 31,
 		keyName = "displayName",
 		name = "Display Name",
 		description = "Shows name of NPCs in the list above them"
@@ -1810,7 +1872,7 @@ public interface BetterNpcHighlightConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 31,
+		position = 32,
 		keyName = "fontBackground",
 		name = "Font Background",
 		description = "Puts an outline, shadow, or nothing behind font overlays"
@@ -1821,7 +1883,7 @@ public interface BetterNpcHighlightConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 32,
+		position = 33,
 		keyName = "npcMinimapMode",
 		name = "Highlight Minimap",
 		description = "Highlights NPC on minimap and/or displays name"
@@ -1832,7 +1894,7 @@ public interface BetterNpcHighlightConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 33,
+		position = 34,
 		keyName = "debugNPC",
 		name = "Debug NPC Info",
 		description = "Highlights all NPCs with their Name and ID"

--- a/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
+++ b/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
@@ -506,63 +506,31 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 			if (npc != null)
 			{
 				String option;
-				if (npc.getName() != null && !config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.NONE) && !config.tagStyleMode().isEmpty())
+				// if there is an NPC name AND
+				// ((tag style none is selected, and so is another option) OR
+				// (tag style none is not selected, and another is))
+				if (npc.getName() != null &&
+						((config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.NONE) && config.tagStyleMode().size() > 1) ||
+						(!config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.NONE) && !config.tagStyleMode().isEmpty())))
 				{
-					// if (checkSpecificNameList(tileNames, npc) ||
-					// 		checkSpecificNameList(trueTileNames, npc) ||
-					// 		checkSpecificNameList(swTileNames, npc) ||
-					// 		checkSpecificNameList(swTrueTileNames, npc) ||
-					// 		checkSpecificNameList(hullNames, npc) ||
-					// 		checkSpecificNameList(areaNames, npc) ||
-					// 		checkSpecificNameList(outlineNames, npc) ||
-					// 		checkSpecificNameList(clickboxNames, npc) ||
-					// 		checkSpecificNameList(turboNames, npc))
-					// {
-					// 	option = "Untag";
-					// }
-					// else
-					// {
-					// 	option = "Tag";
-					// }
-
-					if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TILE))
+					if (checkSpecificNameList(tileNames, npc) ||
+							checkSpecificNameList(trueTileNames, npc) ||
+							checkSpecificNameList(swTileNames, npc) ||
+							checkSpecificNameList(swTrueTileNames, npc) ||
+							checkSpecificNameList(hullNames, npc) ||
+							checkSpecificNameList(areaNames, npc) ||
+							checkSpecificNameList(outlineNames, npc) ||
+							checkSpecificNameList(clickboxNames, npc) ||
+							checkSpecificNameList(turboNames, npc))
 					{
-						option = checkSpecificNameList(tileNames, npc) ? "Untag-Tile" : "Tag-Tile";
-					}
-					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE))
-					{
-						option = checkSpecificNameList(trueTileNames, npc) ? "Untag-True-Tile" : "Tag-True-Tile";
-					}
-					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TILE))
-					{
-						option = checkSpecificNameList(swTileNames, npc) ? "Untag-SW-Tile" : "Tag-SW-Tile";
-					}
-					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE))
-					{
-						option = checkSpecificNameList(swTrueTileNames, npc) ? "Untag-SW-True-Tile" : "Tag-SW-True-Tile";
-					}
-					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.HULL))
-					{
-						option = checkSpecificNameList(hullNames, npc) ? "Untag-Hull" : "Tag-Hull";
-					}
-					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.AREA))
-					{
-						option = checkSpecificNameList(areaNames, npc) ? "Untag-Area" : "Tag-Area";
-					}
-					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.OUTLINE))
-					{
-						option = checkSpecificNameList(outlineNames, npc) ? "Untag-Outline" : "Tag-Outline";
-					}
-					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.CLICKBOX))
-					{
-						option = checkSpecificNameList(clickboxNames, npc) ? "Untag-Clickbox" : "Tag-Clickbox";
+						option = "Untag";
 					}
 					else
 					{
-						option = checkSpecificNameList(turboNames, npc) ? "Untag-Turbo" : "Tag-Turbo";
+						option = "Tag";
 					}
 
-					if (option.contains("Untag-") && (config.highlightMenuNames() || (npc.isDead() && config.deadNpcMenuColor() != null)))
+					if (option.contains("Untag") && (config.highlightMenuNames() || (npc.isDead() && config.deadNpcMenuColor() != null)))
 					{
 						MenuEntry[] menuEntries = client.getMenuEntries();
 						final MenuEntry menuEntry = menuEntries[menuEntries.length - 1];
@@ -632,14 +600,11 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 	{
 		if (event.getType() == MenuAction.RUNELITE)
 		{
-			if ((event.getOption().contains("Tag") || event.getOption().contains("Untag")) && (event.getOption().contains("-Tile")
-				|| event.getOption().contains("-True-Tile") || event.getOption().contains("-SW-Tile") || event.getOption().contains("-SW-True-Tile")
-				|| event.getOption().contains("-Hull") || event.getOption().contains("-Area") || event.getOption().contains("-Outline")
-				|| event.getOption().contains("-Clickbox") || event.getOption().contains("-Turbo")))
+			if (event.getOption().equals("Tag") || event.getOption().equals("Untag"))
 			{
 				final int id = event.getIdentifier();
 				final NPC npc = client.getTopLevelWorldView().npcs().byIndex(id);
-				boolean tag = event.getOption().contains("Tag");
+				boolean tag = event.getOption().equals("Tag");
 				if (npc.getName() != null)
 				{
 					updateListConfig(tag, npc.getName().toLowerCase(), 0);
@@ -731,42 +696,60 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 
 	private void updateListConfig(boolean add, String name, int preset)
 	{
-		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TILE))
-		{
-			config.setTileNames(configListToString(add, name, tileNames, preset));
+		if (!add) {
+			removeAllTagStyles(name);
 		}
-		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE))
-		{
-			config.setTrueTileNames(configListToString(add, name, trueTileNames, preset));
+		else {
+			if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TILE))
+			{
+				config.setTileNames(configListToString(add, name, tileNames, preset));
+			}
+			if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE))
+			{
+				config.setTrueTileNames(configListToString(add, name, trueTileNames, preset));
+			}
+			if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TILE))
+			{
+				config.setSwTileNames(configListToString(add, name, swTileNames, preset));
+			}
+			if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE))
+			{
+				config.setSwTrueTileNames(configListToString(add, name, swTrueTileNames, preset));
+			}
+			if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.HULL))
+			{
+				config.setHullNames(configListToString(add, name, hullNames, preset));
+			}
+			if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.AREA))
+			{
+				config.setAreaNames(configListToString(add, name, areaNames, preset));
+			}
+			if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.OUTLINE))
+			{
+				config.setOutlineNames(configListToString(add, name, outlineNames, preset));
+			}
+			if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.CLICKBOX))
+			{
+				config.setClickboxNames(configListToString(add, name, clickboxNames, preset));
+			}
+			if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TURBO))
+			{
+				config.setTurboNames(configListToString(add, name, turboNames, 0));
+			}
 		}
-		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TILE))
-		{
-			config.setSwTileNames(configListToString(add, name, swTileNames, preset));
-		}
-		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE))
-		{
-			config.setSwTrueTileNames(configListToString(add, name, swTrueTileNames, preset));
-		}
-		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.HULL))
-		{
-			config.setHullNames(configListToString(add, name, hullNames, preset));
-		}
-		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.AREA))
-		{
-			config.setAreaNames(configListToString(add, name, areaNames, preset));
-		}
-		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.OUTLINE))
-		{
-			config.setOutlineNames(configListToString(add, name, outlineNames, preset));
-		}
-		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.CLICKBOX))
-		{
-			config.setClickboxNames(configListToString(add, name, clickboxNames, preset));
-		}
-		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TURBO))
-		{
-			config.setTurboNames(configListToString(add, name, turboNames, 0));
-		}
+	}
+
+	private void removeAllTagStyles(String name) {
+		config.setTileNames(configListToString(false, name, tileNames, 0));
+		config.setTrueTileNames(configListToString(false, name, trueTileNames, 0));
+		config.setSwTileNames(configListToString(false, name, swTileNames, 0));
+		config.setSwTrueTileNames(configListToString(false, name, swTrueTileNames, 0));
+		config.setHullNames(configListToString(false, name, hullNames, 0));
+		config.setAreaNames(configListToString(false, name, areaNames, 0));
+		config.setOutlineNames(configListToString(false, name, outlineNames, 0));
+		config.setClickboxNames(configListToString(false, name, clickboxNames, 0));
+		config.setTurboNames(configListToString(false, name, turboNames, 0));
+
 	}
 
 	private String configListToString(boolean tagOrHide, String name, ArrayList<String> strList, int preset)

--- a/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
+++ b/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
@@ -727,35 +727,35 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 		{
 			config.setTileNames(configListToString(add, name, tileNames, preset));
 		}
-		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE))
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE))
 		{
 			config.setTrueTileNames(configListToString(add, name, trueTileNames, preset));
 		}
-		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TILE))
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TILE))
 		{
 			config.setSwTileNames(configListToString(add, name, swTileNames, preset));
 		}
-		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE))
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE))
 		{
 			config.setSwTrueTileNames(configListToString(add, name, swTrueTileNames, preset));
 		}
-		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.HULL))
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.HULL))
 		{
 			config.setHullNames(configListToString(add, name, hullNames, preset));
 		}
-		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.AREA))
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.AREA))
 		{
 			config.setAreaNames(configListToString(add, name, areaNames, preset));
 		}
-		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.OUTLINE))
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.OUTLINE))
 		{
 			config.setOutlineNames(configListToString(add, name, outlineNames, preset));
 		}
-		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.CLICKBOX))
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.CLICKBOX))
 		{
 			config.setClickboxNames(configListToString(add, name, clickboxNames, preset));
 		}
-		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TURBO))
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TURBO))
 		{
 			config.setTurboNames(configListToString(add, name, turboNames, 0));
 		}

--- a/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
+++ b/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
@@ -498,37 +498,54 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 			if (npc != null)
 			{
 				String option;
-				if (npc.getName() != null && config.tagStyleMode() != BetterNpcHighlightConfig.tagStyleMode.NONE)
+				if (npc.getName() != null && !config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.NONE) && !config.tagStyleMode().isEmpty())
 				{
-					if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.TILE)
+					// if (checkSpecificNameList(tileNames, npc) ||
+					// 		checkSpecificNameList(trueTileNames, npc) ||
+					// 		checkSpecificNameList(swTileNames, npc) ||
+					// 		checkSpecificNameList(swTrueTileNames, npc) ||
+					// 		checkSpecificNameList(hullNames, npc) ||
+					// 		checkSpecificNameList(areaNames, npc) ||
+					// 		checkSpecificNameList(outlineNames, npc) ||
+					// 		checkSpecificNameList(clickboxNames, npc) ||
+					// 		checkSpecificNameList(turboNames, npc))
+					// {
+					// 	option = "Untag";
+					// }
+					// else
+					// {
+					// 	option = "Tag";
+					// }
+
+					if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TILE))
 					{
 						option = checkSpecificNameList(tileNames, npc) ? "Untag-Tile" : "Tag-Tile";
 					}
-					else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE)
+					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE))
 					{
 						option = checkSpecificNameList(trueTileNames, npc) ? "Untag-True-Tile" : "Tag-True-Tile";
 					}
-					else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.SW_TILE)
+					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TILE))
 					{
 						option = checkSpecificNameList(swTileNames, npc) ? "Untag-SW-Tile" : "Tag-SW-Tile";
 					}
-					else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE)
+					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE))
 					{
 						option = checkSpecificNameList(swTrueTileNames, npc) ? "Untag-SW-True-Tile" : "Tag-SW-True-Tile";
 					}
-					else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.HULL)
+					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.HULL))
 					{
 						option = checkSpecificNameList(hullNames, npc) ? "Untag-Hull" : "Tag-Hull";
 					}
-					else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.AREA)
+					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.AREA))
 					{
 						option = checkSpecificNameList(areaNames, npc) ? "Untag-Area" : "Tag-Area";
 					}
-					else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.OUTLINE)
+					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.OUTLINE))
 					{
 						option = checkSpecificNameList(outlineNames, npc) ? "Untag-Outline" : "Tag-Outline";
 					}
-					else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.CLICKBOX)
+					else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.CLICKBOX))
 					{
 						option = checkSpecificNameList(clickboxNames, npc) ? "Untag-Clickbox" : "Tag-Clickbox";
 					}
@@ -542,7 +559,7 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 						MenuEntry[] menuEntries = client.getMenuEntries();
 						final MenuEntry menuEntry = menuEntries[menuEntries.length - 1];
 						String target;
-						if (option.contains("Turbo"))
+						if (checkSpecificNameList(turboNames, npc))
 						{
 							target = ColorUtil.prependColorTag(Text.removeTags(event.getTarget()), Color.getHSBColor(new Random().nextFloat(), 1.0F, 1.0F));
 						}
@@ -561,7 +578,7 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 						if (config.highlightMenuNames() || (npc.isDead() && config.deadNpcMenuColor() != null))
 						{
 							String colorCode;
-							if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.TURBO)
+							if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TURBO))
 							{
 								if (turboColors.size() == 0 && turboNames.contains(npc.getName().toLowerCase()))
 								{
@@ -706,39 +723,39 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 
 	private void updateListConfig(boolean add, String name, int preset)
 	{
-		if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.TILE)
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TILE))
 		{
 			config.setTileNames(configListToString(add, name, tileNames, preset));
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE))
 		{
 			config.setTrueTileNames(configListToString(add, name, trueTileNames, preset));
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.SW_TILE)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TILE))
 		{
 			config.setSwTileNames(configListToString(add, name, swTileNames, preset));
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE))
 		{
 			config.setSwTrueTileNames(configListToString(add, name, swTrueTileNames, preset));
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.HULL)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.HULL))
 		{
 			config.setHullNames(configListToString(add, name, hullNames, preset));
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.AREA)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.AREA))
 		{
 			config.setAreaNames(configListToString(add, name, areaNames, preset));
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.OUTLINE)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.OUTLINE))
 		{
 			config.setOutlineNames(configListToString(add, name, outlineNames, preset));
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.CLICKBOX)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.CLICKBOX))
 		{
 			config.setClickboxNames(configListToString(add, name, clickboxNames, preset));
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.TURBO)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TURBO))
 		{
 			config.setTurboNames(configListToString(add, name, turboNames, 0));
 		}
@@ -1012,35 +1029,35 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 	 */
 	public Color getTagColor()
 	{
-		if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.TILE)
+		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TILE))
 		{
 			return config.tileColor();
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TRUE_TILE))
 		{
 			return config.trueTileColor();
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.SW_TILE)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TILE))
 		{
 			return config.swTileColor();
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.SW_TRUE_TILE))
 		{
 			return config.swTrueTileColor();
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.HULL)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.HULL))
 		{
 			return config.hullColor();
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.AREA)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.AREA))
 		{
 			return config.areaColor();
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.OUTLINE)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.OUTLINE))
 		{
 			return config.outlineColor();
 		}
-		else if (config.tagStyleMode() == BetterNpcHighlightConfig.tagStyleMode.CLICKBOX)
+		else if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.CLICKBOX))
 		{
 			return config.clickboxColor();
 		}

--- a/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
+++ b/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
@@ -442,6 +442,10 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 				case "presetFillColor4":
 				case "presetColor5":
 				case "presetFillColor5":
+				case "useGlobalTileColor":
+				case "globalTileColor":
+				case "globalFillColor":
+				case "globaltileWidth":
 					recreateList();
 					break;
 			}
@@ -696,10 +700,12 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 
 	private void updateListConfig(boolean add, String name, int preset)
 	{
-		if (!add) {
+		if (!add)
+		{
 			removeAllTagStyles(name);
 		}
-		else {
+		else
+		{
 			if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TILE))
 			{
 				config.setTileNames(configListToString(add, name, tileNames, preset));
@@ -739,7 +745,8 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 		}
 	}
 
-	private void removeAllTagStyles(String name) {
+	private void removeAllTagStyles(String name)
+	{
 		config.setTileNames(configListToString(false, name, tileNames, 0));
 		config.setTrueTileNames(configListToString(false, name, trueTileNames, 0));
 		config.setSwTileNames(configListToString(false, name, swTileNames, 0));
@@ -1022,6 +1029,10 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 	 */
 	public Color getTagColor()
 	{
+		if (config.useGlobalTileColor())
+		{
+			return config.globalTileColor();
+		}
 		if (config.tagStyleMode().contains(BetterNpcHighlightConfig.tagStyleMode.TILE))
 		{
 			return config.tileColor();

--- a/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
+++ b/src/main/java/com/betternpchighlight/BetterNpcHighlightPlugin.java
@@ -445,7 +445,6 @@ public class BetterNpcHighlightPlugin extends Plugin implements KeyListener
 				case "useGlobalTileColor":
 				case "globalTileColor":
 				case "globalFillColor":
-				case "globaltileWidth":
 					recreateList();
 					break;
 			}

--- a/src/main/java/com/betternpchighlight/NPCInfo.java
+++ b/src/main/java/com/betternpchighlight/NPCInfo.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.NPC;
 import net.runelite.client.plugins.slayer.SlayerPluginService;
+import java.awt.Color;
 
 @Getter
 @Setter
@@ -24,11 +25,14 @@ public class NPCInfo
 
 	public NPCInfo(NPC npc, BetterNpcHighlightPlugin plugin, SlayerPluginService slayerPluginService, BetterNpcHighlightConfig config)
 	{
+		Color globalTileColor = config.useGlobalTileColor() ? config.globalTileColor() : null;
+		Color globalFillColor = config.useGlobalTileColor() ? config.globalFillColor() : null;
+
 		this.npc = npc;
-		this.tile = plugin.checkSpecificList(plugin.tileNames, plugin.tileIds, npc, config.tileColor(), config.tileFillColor());
-		this.trueTile = plugin.checkSpecificList(plugin.trueTileNames, plugin.trueTileIds, npc, config.trueTileColor(), config.trueTileFillColor());
-		this.swTile = plugin.checkSpecificList(plugin.swTileNames, plugin.swTileIds, npc, config.swTileColor(), config.swTileFillColor());
-		this.swTrueTile = plugin.checkSpecificList(plugin.swTrueTileNames, plugin.swTrueTileIds, npc, config.swTrueTileColor(), config.swTrueTileFillColor());
+		this.tile = plugin.checkSpecificList(plugin.tileNames, plugin.tileIds, npc, coalesceColor(globalTileColor, config.tileColor()), coalesceColor(globalFillColor, config.tileFillColor()));
+		this.trueTile = plugin.checkSpecificList(plugin.trueTileNames, plugin.trueTileIds, npc, coalesceColor(globalTileColor, config.trueTileColor()), coalesceColor(globalFillColor, config.trueTileFillColor()));
+		this.swTile = plugin.checkSpecificList(plugin.swTileNames, plugin.swTileIds, npc, coalesceColor(globalTileColor, config.swTileColor()), coalesceColor(globalFillColor, config.swTileFillColor()));
+		this.swTrueTile = plugin.checkSpecificList(plugin.swTrueTileNames, plugin.swTrueTileIds, npc, coalesceColor(globalTileColor, config.swTrueTileColor()), coalesceColor(globalFillColor, config.swTrueTileFillColor()));
 		this.hull = plugin.checkSpecificList(plugin.hullNames, plugin.hullIds, npc, config.hullColor(), config.hullFillColor());
 		this.area = plugin.checkSpecificList(plugin.areaNames, plugin.areaIds, npc, config.areaColor(), null);
 		this.outline = plugin.checkSpecificList(plugin.outlineNames, plugin.outlineIds, npc, config.outlineColor(), null);
@@ -36,5 +40,10 @@ public class NPCInfo
 		this.turbo = plugin.checkSpecificList(plugin.turboNames, plugin.turboIds, npc, null, null);
 		this.isTask = plugin.checkSlayerPluginEnabled() && slayerPluginService != null && slayerPluginService.getTargets().contains(npc);
 		this.ignoreDead = plugin.checkSpecificNameList(plugin.ignoreDeadExclusionList, npc) || plugin.checkSpecificIdList(plugin.ignoreDeadExclusionIDList, npc);
+	}
+
+	private Color coalesceColor(Color color, Color defaultColor)
+	{
+		return color != null ? color : defaultColor;
 	}
 }


### PR DESCRIPTION
This is a followup to https://github.com/MoreBuchus/buchus-plugins/pull/119

I have ironed out issues with the original implementation. This was achieved by making all tag styles become untagged, regardless of which menu options are selected when untagging.

Another change that needed to occur for consistency is the menu option name for tagging. Currently the wording changes depending on which highlight style is selected, but since multiple styles can be selected I simplified it down to just "Tag" and "Untag".

Additionally I added a set of options that allow for setting a singular global tag color. This simplifies the tagging process by not making the user set each tag option color individually. I opted to only have this override the tile styles and not the hull, outline, etc. Additionally, this will not override preset colors. Open to wording changes on the config descriptions. I can also back this commit out if this is undesired, or you would prefer it in a separate PR.