### PR TITLE
CoX Additions: Expand instance timer feature (depends on #145)

### DIFF
--- a/src/main/java/com/coxadditions/CoxAdditionsConfig.java
+++ b/src/main/java/com/coxadditions/CoxAdditionsConfig.java
@@ -233,10 +233,19 @@ public interface CoxAdditionsConfig extends Config
 	}
 
 	@ConfigItem(
+		name = "Instance Timer On During Raid",
+		keyName = "instanceTimerInRaid",
+		description = "Toggle to keep the instance timer running during the raid.",
+		position = 1,
+		section = roomSection
+	)
+	default boolean instanceTimerInRaid() {return false;}
+
+	@ConfigItem(
 		name = "Left Click Leave CC",
 		keyName = "leftClickLeave",
 		description = "Left click leave corp simulator",
-		position = 1,
+		position = 2,
 		section = roomSection
 	)
 	default boolean leftClickLeave()
@@ -248,7 +257,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "CC Warning",
 		keyName = "ccWarning",
 		description = "Highlights the entrance to CoX. Red = not in a CC, Yellow = in a CC, but no party made.",
-		position = 2,
+		position = 3,
 		section = roomSection
 	)
 	default boolean ccWarning()
@@ -260,7 +269,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Hotkey",
 		keyName = "hotkey",
 		description = "Configures the hotkey used for hotkey configs in Cox Additions",
-		position = 3,
+		position = 4,
 		section = roomSection
 	)
 	default Keybind hotkey()
@@ -272,7 +281,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Hotkey Swap Private Chest",
 		keyName = "hotkeySwapBank",
 		description = "Switches your CoX chest from shared to private when holding the hotkey",
-		position = 4,
+		position = 5,
 		section = roomSection
 	)
 	default boolean hotkeySwapBank()
@@ -284,7 +293,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Prayer Enh. Timer",
 		keyName = "detailedPrayerEnhance",
 		description = "Displays a detailed prayer enhance timer in CoX",
-		position = 5,
+		position = 6,
 		section = roomSection
 	)
 	default enhanceMode detailedPrayerEnhance()
@@ -296,7 +305,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Raids Pots Status Overlay",
 		keyName = "raidsPotsStatusOverlay",
 		description = "Displays how many overload and enhance ticks each player has left. Must be in party to see other players",
-		position = 6,
+		position = 7,
 		section = roomSection
 	)
 	default boolean raidsPotsStatusOverlay()
@@ -308,7 +317,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Pots Height",
 		keyName = "raidsPotsHeight",
 		description = "The height at which to display the Raids Pots Status Overlay",
-		position = 7,
+		position = 8,
 		section = roomSection
 	)
 	default RaidsPotsLoc raidsPotsHeight()
@@ -320,7 +329,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Raids Pots Icon Size",
 		keyName = "raidsPotsIconSize",
 		description = "Changes the size of the raids pots icon",
-		position = 8,
+		position = 9,
 		section = roomSection
 	)
 	default int raidsPotsIconSize()
@@ -332,7 +341,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Anti-Aliasing",
 		keyName = "antiAlias",
 		description = "Turns on anti-aliasing for all overlays. Makes them smoother.",
-		position = 9,
+		position = 10,
 		section = roomSection
 	)
 	default boolean antiAlias()
@@ -344,7 +353,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "—————— True Tile ——————",
 		keyName = "room divider",
 		description = "",
-		position = 10,
+		position = 11,
 		section = roomSection
 	)
 	void roomDivider();
@@ -353,7 +362,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "True Location List",
 		keyName = "tlList",
 		description = "NPC's in this list will be highlighted with true location. ONLY works with Cox bosses",
-		position = 11,
+		position = 12,
 		section = roomSection
 	)
 	default String tlList()
@@ -366,7 +375,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "True Location Width",
 		keyName = "tlThiCC",
 		description = "Outline width for true location highlight",
-		position = 12,
+		position = 13,
 		section = roomSection
 	)
 	default double tlThiCC()
@@ -379,7 +388,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "True Location Color",
 		keyName = "tlColor",
 		description = "Highlight color for true location",
-		position = 13,
+		position = 14,
 		section = roomSection
 	)
 	default Color tlColor()
@@ -392,7 +401,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "True Location Fill Color",
 		keyName = "tlFillColor",
 		description = "Fill color for true location",
-		position = 14,
+		position = 15,
 		section = roomSection
 	)
 	default Color tlFillColor()
@@ -404,7 +413,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "True Tile Line Type",
 		keyName = "tileLines",
 		description = "Sets the true tile outline to regular, dashed, or corners only",
-		position = 15,
+		position = 16,
 		section = roomSection
 	)
 	default lineType tileLines()
@@ -416,7 +425,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "—————— Puzzle Rooms ——————",
 		keyName = "puzzle divider",
 		description = "",
-		position = 16,
+		position = 17,
 		section = roomSection
 	)
 	void puzzleDivider();
@@ -425,7 +434,7 @@ public interface CoxAdditionsConfig extends Config
 		keyName = "chestGroupsHighlight",
 		name = "Highlight Grub Chests",
 		description = "CoX CM ONLY - Highlights groups of 4 chests",
-		position = 17,
+		position = 18,
 		section = roomSection
 	)
 	default Set<HighlightChestGroups> chestGroupsHighlight()
@@ -437,7 +446,7 @@ public interface CoxAdditionsConfig extends Config
 		keyName = "chestGroupsHighlightStyle",
 		name = "Chest Highlight Style",
 		description = "Selects the highlight style for 'Highlight Grub Chests'",
-		position = 18,
+		position = 19,
 		section = roomSection
 	)
 	default GrubChestStyle chestGroupsHighlightStyle()
@@ -449,7 +458,7 @@ public interface CoxAdditionsConfig extends Config
 		keyName = "grubsInfobox",
 		name = "Grubs Counter",
 		description = "Displays an infobox showing the total amount of cavern grubs collected. Works with party",
-		position = 19,
+		position = 20,
 		section = roomSection
 	)
 	default grubsMode grubsInfobox()
@@ -461,7 +470,7 @@ public interface CoxAdditionsConfig extends Config
 		keyName = "grubsAmount",
 		name = "Grubs Amount",
 		description = "Set to the amount of grubs you/your team want to collect. The cavern grub counter's text will turn green when this number is reached.",
-		position = 20,
+		position = 21,
 		section = roomSection
 	)
 	default int grubsAmount()
@@ -473,7 +482,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Hotkey Swap Smash",
 		keyName = "hotkeySwapSmash",
 		description = "Switches attack and smash when holding the hotkey",
-		position = 21,
+		position = 22,
 		section = roomSection
 	)
 	default boolean hotkeySwapSmash()
@@ -485,7 +494,7 @@ public interface CoxAdditionsConfig extends Config
 		keyName = "iceDemonHp",
 		name = "Ice Demon HP",
 		description = "Displays Ice Demon HP percent while lighting kindling",
-		position = 22,
+		position = 23,
 		section = roomSection
 	)
 	default boolean iceDemonHp()
@@ -497,7 +506,7 @@ public interface CoxAdditionsConfig extends Config
 		keyName = "swapCoXKeystone",
 		name = "Left Click Drop Keystone",
 		description = "swaps use with drop for the keystone crystal at tightrope",
-		position = 23,
+		position = 24,
 		section = roomSection
 	)
 	default boolean swapCoXKeystone()
@@ -509,7 +518,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "—————— Combat Rooms ——————",
 		keyName = "combat divider",
 		description = "",
-		position = 24,
+		position = 25,
 		section = roomSection
 	)
 	void combatDivider();
@@ -518,7 +527,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Small Muttadile HP",
 		keyName = "smallMuttaHp",
 		description = "Displays the health percentage of small Muttadile while meat tree is alive",
-		position = 25,
+		position = 26,
 		section = roomSection
 	)
 	default boolean smallMuttaHp()
@@ -530,7 +539,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Big Muttadile HP",
 		keyName = "bigMuttaHp",
 		description = "Displays the health percentage of big Muttadile after the small Muttadile is dead",
-		position = 26,
+		position = 27,
 		section = roomSection
 	)
 	default boolean bigMuttaHp()
@@ -542,7 +551,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Vanguard HP Infobox",
 		keyName = "vangInfobox",
 		description = "Displays the hp left on each vanguard",
-		position = 27,
+		position = 28,
 		section = roomSection
 	)
 	default boolean vangInfobox()
@@ -554,7 +563,7 @@ public interface CoxAdditionsConfig extends Config
 		keyName = "showPanel",
 		name = "Vanguard Overloads Overlay",
 		description = "Shows how many Overloads have been received from Vanguards. Works with party.",
-		position = 28,
+		position = 29,
 		section = roomSection
 	)
 	default boolean showPanel()
@@ -566,7 +575,7 @@ public interface CoxAdditionsConfig extends Config
 		keyName = "overloadChatMessage",
 		name = "Overload Dropped Chat Message",
 		description = "Prints a chat message when a player receives an Overload from Vanguards. Works with party.",
-		position = 29,
+		position = 30,
 		section = roomSection
 	)
 	default boolean overloadChatMessage()

--- a/src/main/java/com/coxadditions/CoxAdditionsConfig.java
+++ b/src/main/java/com/coxadditions/CoxAdditionsConfig.java
@@ -235,17 +235,32 @@ public interface CoxAdditionsConfig extends Config
 	@ConfigItem(
 		name = "Instance Timer On During Raid",
 		keyName = "instanceTimerInRaid",
-		description = "Toggle to keep the instance timer running during the raid.",
+		description = "Enable to keep the instance timer running during the raid.",
 		position = 1,
 		section = roomSection
 	)
-	default boolean instanceTimerInRaid() {return false;}
+	default boolean instanceTimerInRaid()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		name = "Instance Timer Sharing",
+		keyName = "instanceTimerSharing",
+		description = "Allows syncing the instance timer with others in the raid if they have this enabled. (Requires Party)",
+		position = 2,
+		section = roomSection
+	)
+	default boolean instanceTimerSharing()
+	{
+		return true;
+	}
 
 	@ConfigItem(
 		name = "Left Click Leave CC",
 		keyName = "leftClickLeave",
 		description = "Left click leave corp simulator",
-		position = 2,
+		position = 3,
 		section = roomSection
 	)
 	default boolean leftClickLeave()
@@ -257,7 +272,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "CC Warning",
 		keyName = "ccWarning",
 		description = "Highlights the entrance to CoX. Red = not in a CC, Yellow = in a CC, but no party made.",
-		position = 3,
+		position = 4,
 		section = roomSection
 	)
 	default boolean ccWarning()
@@ -269,7 +284,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Hotkey",
 		keyName = "hotkey",
 		description = "Configures the hotkey used for hotkey configs in Cox Additions",
-		position = 4,
+		position = 5,
 		section = roomSection
 	)
 	default Keybind hotkey()
@@ -281,7 +296,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Hotkey Swap Private Chest",
 		keyName = "hotkeySwapBank",
 		description = "Switches your CoX chest from shared to private when holding the hotkey",
-		position = 5,
+		position = 6,
 		section = roomSection
 	)
 	default boolean hotkeySwapBank()
@@ -293,7 +308,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Prayer Enh. Timer",
 		keyName = "detailedPrayerEnhance",
 		description = "Displays a detailed prayer enhance timer in CoX",
-		position = 6,
+		position = 7,
 		section = roomSection
 	)
 	default enhanceMode detailedPrayerEnhance()
@@ -305,7 +320,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Raids Pots Status Overlay",
 		keyName = "raidsPotsStatusOverlay",
 		description = "Displays how many overload and enhance ticks each player has left. Must be in party to see other players",
-		position = 7,
+		position = 8,
 		section = roomSection
 	)
 	default boolean raidsPotsStatusOverlay()
@@ -317,7 +332,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Pots Height",
 		keyName = "raidsPotsHeight",
 		description = "The height at which to display the Raids Pots Status Overlay",
-		position = 8,
+		position = 9,
 		section = roomSection
 	)
 	default RaidsPotsLoc raidsPotsHeight()
@@ -329,7 +344,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Raids Pots Icon Size",
 		keyName = "raidsPotsIconSize",
 		description = "Changes the size of the raids pots icon",
-		position = 9,
+		position = 10,
 		section = roomSection
 	)
 	default int raidsPotsIconSize()
@@ -341,7 +356,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Anti-Aliasing",
 		keyName = "antiAlias",
 		description = "Turns on anti-aliasing for all overlays. Makes them smoother.",
-		position = 10,
+		position = 11,
 		section = roomSection
 	)
 	default boolean antiAlias()
@@ -353,7 +368,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "—————— True Tile ——————",
 		keyName = "room divider",
 		description = "",
-		position = 11,
+		position = 12,
 		section = roomSection
 	)
 	void roomDivider();
@@ -362,7 +377,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "True Location List",
 		keyName = "tlList",
 		description = "NPC's in this list will be highlighted with true location. ONLY works with Cox bosses",
-		position = 12,
+		position = 13,
 		section = roomSection
 	)
 	default String tlList()
@@ -375,7 +390,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "True Location Width",
 		keyName = "tlThiCC",
 		description = "Outline width for true location highlight",
-		position = 13,
+		position = 14,
 		section = roomSection
 	)
 	default double tlThiCC()
@@ -388,7 +403,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "True Location Color",
 		keyName = "tlColor",
 		description = "Highlight color for true location",
-		position = 14,
+		position = 15,
 		section = roomSection
 	)
 	default Color tlColor()
@@ -401,7 +416,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "True Location Fill Color",
 		keyName = "tlFillColor",
 		description = "Fill color for true location",
-		position = 15,
+		position = 16,
 		section = roomSection
 	)
 	default Color tlFillColor()
@@ -413,7 +428,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "True Tile Line Type",
 		keyName = "tileLines",
 		description = "Sets the true tile outline to regular, dashed, or corners only",
-		position = 16,
+		position = 17,
 		section = roomSection
 	)
 	default lineType tileLines()
@@ -425,7 +440,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "—————— Puzzle Rooms ——————",
 		keyName = "puzzle divider",
 		description = "",
-		position = 17,
+		position = 18,
 		section = roomSection
 	)
 	void puzzleDivider();
@@ -434,7 +449,7 @@ public interface CoxAdditionsConfig extends Config
 		keyName = "chestGroupsHighlight",
 		name = "Highlight Grub Chests",
 		description = "CoX CM ONLY - Highlights groups of 4 chests",
-		position = 18,
+		position = 19,
 		section = roomSection
 	)
 	default Set<HighlightChestGroups> chestGroupsHighlight()
@@ -446,7 +461,7 @@ public interface CoxAdditionsConfig extends Config
 		keyName = "chestGroupsHighlightStyle",
 		name = "Chest Highlight Style",
 		description = "Selects the highlight style for 'Highlight Grub Chests'",
-		position = 19,
+		position = 20,
 		section = roomSection
 	)
 	default GrubChestStyle chestGroupsHighlightStyle()
@@ -458,7 +473,7 @@ public interface CoxAdditionsConfig extends Config
 		keyName = "grubsInfobox",
 		name = "Grubs Counter",
 		description = "Displays an infobox showing the total amount of cavern grubs collected. Works with party",
-		position = 20,
+		position = 21,
 		section = roomSection
 	)
 	default grubsMode grubsInfobox()
@@ -470,7 +485,7 @@ public interface CoxAdditionsConfig extends Config
 		keyName = "grubsAmount",
 		name = "Grubs Amount",
 		description = "Set to the amount of grubs you/your team want to collect. The cavern grub counter's text will turn green when this number is reached.",
-		position = 21,
+		position = 22,
 		section = roomSection
 	)
 	default int grubsAmount()
@@ -482,7 +497,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Hotkey Swap Smash",
 		keyName = "hotkeySwapSmash",
 		description = "Switches attack and smash when holding the hotkey",
-		position = 22,
+		position = 23,
 		section = roomSection
 	)
 	default boolean hotkeySwapSmash()
@@ -494,7 +509,7 @@ public interface CoxAdditionsConfig extends Config
 		keyName = "iceDemonHp",
 		name = "Ice Demon HP",
 		description = "Displays Ice Demon HP percent while lighting kindling",
-		position = 23,
+		position = 24,
 		section = roomSection
 	)
 	default boolean iceDemonHp()
@@ -506,7 +521,7 @@ public interface CoxAdditionsConfig extends Config
 		keyName = "swapCoXKeystone",
 		name = "Left Click Drop Keystone",
 		description = "swaps use with drop for the keystone crystal at tightrope",
-		position = 24,
+		position = 25,
 		section = roomSection
 	)
 	default boolean swapCoXKeystone()
@@ -518,7 +533,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "—————— Combat Rooms ——————",
 		keyName = "combat divider",
 		description = "",
-		position = 25,
+		position = 26,
 		section = roomSection
 	)
 	void combatDivider();
@@ -527,7 +542,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Small Muttadile HP",
 		keyName = "smallMuttaHp",
 		description = "Displays the health percentage of small Muttadile while meat tree is alive",
-		position = 26,
+		position = 27,
 		section = roomSection
 	)
 	default boolean smallMuttaHp()
@@ -539,7 +554,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Big Muttadile HP",
 		keyName = "bigMuttaHp",
 		description = "Displays the health percentage of big Muttadile after the small Muttadile is dead",
-		position = 27,
+		position = 28,
 		section = roomSection
 	)
 	default boolean bigMuttaHp()
@@ -551,7 +566,7 @@ public interface CoxAdditionsConfig extends Config
 		name = "Vanguard HP Infobox",
 		keyName = "vangInfobox",
 		description = "Displays the hp left on each vanguard",
-		position = 28,
+		position = 29,
 		section = roomSection
 	)
 	default boolean vangInfobox()
@@ -563,7 +578,7 @@ public interface CoxAdditionsConfig extends Config
 		keyName = "showPanel",
 		name = "Vanguard Overloads Overlay",
 		description = "Shows how many Overloads have been received from Vanguards. Works with party.",
-		position = 29,
+		position = 30,
 		section = roomSection
 	)
 	default boolean showPanel()
@@ -575,7 +590,7 @@ public interface CoxAdditionsConfig extends Config
 		keyName = "overloadChatMessage",
 		name = "Overload Dropped Chat Message",
 		description = "Prints a chat message when a player receives an Overload from Vanguards. Works with party.",
-		position = 30,
+		position = 31,
 		section = roomSection
 	)
 	default boolean overloadChatMessage()
@@ -923,7 +938,8 @@ public interface CoxAdditionsConfig extends Config
 	{
 		OFF,
 		OVERHEAD,
-		INFOBOX
+		INFOBOX,
+		BOTH
 	}
 
 	enum enhanceMode

--- a/src/main/java/com/coxadditions/CoxAdditionsPlugin.java
+++ b/src/main/java/com/coxadditions/CoxAdditionsPlugin.java
@@ -892,7 +892,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 				removeInfobox("Grubs");
 			}
 
-			if (!hasRaidStarted && isInstanceTimerRunning && isRaidLeader && partyService.isInParty())
+			if (config.instanceTimerSharing() && !hasRaidStarted && isInstanceTimerRunning && isRaidLeader && partyService.isInParty())
 			{
 				if (instanceTimerShareCooldown <= 1)
 				{
@@ -919,6 +919,11 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 	@Subscribe
 	public void onPartyInstanceTimerSync(PartyInstanceTimerSync e)
 	{
+		if (!config.instanceTimerSharing())
+		{
+			return;
+		}
+
 		if (partyService.getLocalMember().getMemberId() != e.getMemberId())
 		{
 			if (!isInstanceTimerRunning && inRaid && client.getFriendsChatManager() != null)
@@ -1552,6 +1557,8 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 	public void onVarbitChanged(VarbitChanged e)
 	{
 		inRaid = client.getVarbitValue(VarbitID.RAIDS_CLIENT_INDUNGEON) == 1;
+		hasRaidStarted = client.getVarbitValue(VarbitID.RAIDS_CLIENT_PROGRESS) > 0;
+		isRaidLeader = client.getVarbitValue(VarbitID.RAIDS_CLIENT_ISLEADER) == 1;
 
 		if (inRaid)
 		{

--- a/src/main/java/com/coxadditions/CoxAdditionsPlugin.java
+++ b/src/main/java/com/coxadditions/CoxAdditionsPlugin.java
@@ -45,24 +45,28 @@ import java.awt.Font;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.AnimationID;
+import net.runelite.api.gameval.AnimationID;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
 import net.runelite.api.GameState;
+import net.runelite.api.IndexedObjectSet;
 import net.runelite.api.InstanceTemplates;
-import net.runelite.api.InventoryID;
-import net.runelite.api.ItemID;
+import net.runelite.api.gameval.InventoryID;
+import net.runelite.api.gameval.ItemID;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
+import net.runelite.api.Menu;
 import net.runelite.api.NPC;
-import net.runelite.api.NpcID;
+import net.runelite.api.gameval.NpcID;
 import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.api.Projectile;
 import net.runelite.api.Skill;
-import net.runelite.api.VarPlayer;
-import net.runelite.api.Varbits;
+import net.runelite.api.gameval.SpotanimID;
+import net.runelite.api.gameval.VarPlayerID;
+import net.runelite.api.gameval.VarbitID;
+import net.runelite.api.WorldView;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ActorDeath;
@@ -534,7 +538,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 		tlList.clear();
 		for (String str : config.tlList().split(","))
 		{
-			if (!str.trim().equals(""))
+			if (!str.trim().isEmpty())
 			{
 				tlList.add(str.trim().toLowerCase());
 			}
@@ -543,7 +547,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 		chestHighlightIdList.clear();
 		for (String str : config.highlightChestItems().split(","))
 		{
-			if (!str.trim().equals(""))
+			if (!str.trim().isEmpty())
 			{
 				try
 				{
@@ -559,7 +563,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 		chestHighlightIdList2.clear();
 		for (String str : config.highlightChestItems2().split(","))
 		{
-			if (!str.trim().equals(""))
+			if (!str.trim().isEmpty())
 			{
 				try
 				{
@@ -626,7 +630,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 					tlList.clear();
 					for (String str : config.tlList().split(","))
 					{
-						if (!str.trim().equals(""))
+						if (!str.trim().isEmpty())
 						{
 							tlList.add(str.trim().toLowerCase());
 						}
@@ -636,7 +640,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 					chestHighlightIdList.clear();
 					for (String str : config.highlightChestItems().split(","))
 					{
-						if (!str.trim().equals(""))
+						if (!str.trim().isEmpty())
 						{
 							try
 							{
@@ -653,7 +657,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 					chestHighlightIdList2.clear();
 					for (String str : config.highlightChestItems2().split(","))
 					{
-						if (!str.trim().equals(""))
+						if (!str.trim().isEmpty())
 						{
 							try
 							{
@@ -776,7 +780,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 				}
 			}
 
-			List<NPC> npcs = client.getNpcs();
+			IndexedObjectSet<? extends NPC> npcs = client.getTopLevelWorldView().npcs();
 			inVangs = false;
 			for (NPC npc : npcs)
 			{
@@ -997,10 +1001,11 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 				if (client.getLocalPlayer() != null)
 				{
 					WorldPoint wp = client.getLocalPlayer().getWorldLocation();
+					WorldView worldView = client.getTopLevelWorldView();
 
-					if (wp.getX() - client.getBaseX() == chestX && wp.getY() - client.getBaseY() == chestY)
+					if (wp.getX() - worldView.getBaseX() == chestX && wp.getY() - worldView.getBaseY() == chestY)
 					{
-						int grubs = client.getItemContainer(InventoryID.INVENTORY).count(ItemID.CAVERN_GRUBS);
+						int grubs = client.getItemContainer(InventoryID.INV).count(ItemID.RAIDS_THIEVINGCHEST_GRUBS);
 
 						int delta = grubs - previousGrubs;
 						totalGrubs += delta;
@@ -1051,8 +1056,8 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 	{
 		if (e.getActor().getName() != null && client.getLocalPlayer() != null && e.getActor().getName().equals(client.getLocalPlayer().getName()) && inRaid)
 		{
-			pickedHerb = e.getActor().getAnimation() == AnimationID.FARMING_HARVEST_HERB;
-			potMade = e.getActor().getAnimation() == AnimationID.HERBLORE_POTIONMAKING;
+			pickedHerb = e.getActor().getAnimation() == AnimationID.PICKING_LOW;
+			potMade = e.getActor().getAnimation() == AnimationID.HUMAN_HERBING_VIAL;
 		}
 	}
 
@@ -1061,17 +1066,17 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 	{
 		if (inRaid)
 		{
-			int nox = e.getItemContainer().count(ItemID.GRIMY_NOXIFER) + e.getItemContainer().count(ItemID.NOXIFER);
-			int golpar = e.getItemContainer().count(ItemID.GRIMY_GOLPAR) + e.getItemContainer().count(ItemID.GOLPAR);
-			int buchus = e.getItemContainer().count(ItemID.GRIMY_BUCHU_LEAF) + e.getItemContainer().count(ItemID.BUCHU_LEAF);
-			int brews = e.getItemContainer().count(ItemID.XERICS_AID_4_20984);
-			int revites = e.getItemContainer().count(ItemID.REVITALISATION_4_20960);
-			int enhances = e.getItemContainer().count(ItemID.PRAYER_ENHANCE_4_20972);
-			int elders = e.getItemContainer().count(ItemID.ELDER_4_20924);
-			int twisteds = e.getItemContainer().count(ItemID.TWISTED_4_20936);
-			int kodais = e.getItemContainer().count(ItemID.KODAI_4_20948);
-			int overloads = e.getItemContainer().count(ItemID.OVERLOAD_4_20996);
-			int grubs = e.getItemContainer().count(ItemID.CAVERN_GRUBS);
+			int nox = e.getItemContainer().count(ItemID.RAIDS_GRIMY_NOXIFER) + e.getItemContainer().count(ItemID.RAIDS_NOXIFER);
+			int golpar = e.getItemContainer().count(ItemID.RAIDS_GRIMY_GOLPAR) + e.getItemContainer().count(ItemID.RAIDS_GOLPAR);
+			int buchus = e.getItemContainer().count(ItemID.RAIDS_GRIMY_BUCHULEAF) + e.getItemContainer().count(ItemID.RAIDS_BUCHULEAF);
+			int brews = e.getItemContainer().count(ItemID.RAIDS_VIAL_XERICAID_STRONG_4);
+			int revites = e.getItemContainer().count(ItemID.RAIDS_VIAL_REVITALISATION_STRONG_4);
+			int enhances = e.getItemContainer().count(ItemID.RAIDS_VIAL_PRAYER_STRONG_4);
+			int elders = e.getItemContainer().count(ItemID.RAIDS_VIAL_ELDER_STRONG_4);
+			int twisteds = e.getItemContainer().count(ItemID.RAIDS_VIAL_TWISTED_STRONG_4);
+			int kodais = e.getItemContainer().count(ItemID.RAIDS_VIAL_KODAI_STRONG_4);
+			int overloads = e.getItemContainer().count(ItemID.RAIDS_VIAL_OVERLOAD_STRONG_4);
+			int grubs = e.getItemContainer().count(ItemID.RAIDS_THIEVINGCHEST_GRUBS);
 
 			if (e.getContainerId() == 93) //Inventory
 			{
@@ -1133,9 +1138,9 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 				inventoryTwisteds = twisteds;
 				inventoryKodais = kodais;
 				inventoryOverloads = overloads;
-				pickedJuice = e.getItemContainer().count(ItemID.ENDARKENED_JUICE);
-				pickedShrooms = e.getItemContainer().count(ItemID.STINKHORN_MUSHROOM);
-				pickedCicely = e.getItemContainer().count(ItemID.CICELY);
+				pickedJuice = e.getItemContainer().count(ItemID.RAIDS_ENDARKENED_JUICE);
+				pickedShrooms = e.getItemContainer().count(ItemID.RAIDS_STINKHORN_MUSHROOM);
+				pickedCicely = e.getItemContainer().count(ItemID.RAIDS_CICELY);
 
 				previousGrubs = grubs;
 			}
@@ -1177,23 +1182,23 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 
 			switch (id)
 			{
-				case NpcID.GREAT_OLM_LEFT_CLAW:
-				case NpcID.GREAT_OLM_LEFT_CLAW_7555:
+				case NpcID.OLM_HAND_LEFT_SPAWNING:
+				case NpcID.OLM_HAND_LEFT:
 					meleeHand = npc;
 					break;
-				case NpcID.GREAT_OLM_RIGHT_CLAW:
-				case NpcID.GREAT_OLM_RIGHT_CLAW_7553:
+				case NpcID.OLM_HAND_RIGHT_SPAWNING:
+				case NpcID.OLM_HAND_RIGHT:
 					mageHand = npc;
 					break;
-				case NpcID.ICE_DEMON:
+				case NpcID.RAIDS_ICEDEMON_NONCOMBAT:
 					iceDemon = npc;
 					break;
-				case NpcID.MUTTADILE_7562: //Baby muttadile
+				case NpcID.RAIDS_DOGODILE_JUNIOR: //Baby muttadile
 					smallMuttaAlive = true;
 					smallMutta = npc;
 					break;
-				case NpcID.MUTTADILE: //Big muttadile in water
-				case NpcID.MUTTADILE_7563: //Big muttadile
+				case NpcID.RAIDS_DOGODILE_SUBMERGED: //Big muttadile in water
+				case NpcID.RAIDS_DOGODILE: //Big muttadile
 					bigMutta = npc;
 					break;
 			}
@@ -1204,11 +1209,11 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 				{
 					olmHead = npc;
 					olmSpawned = true;
-					if (id == NpcID.GREAT_OLM)
+					if (id == NpcID.OLM_HEAD_SPAWNING)
 					{
 						olmTile = npc.getLocalLocation();
 					}
-					else if (id == NpcID.GREAT_OLM_7554)
+					else if (id == NpcID.OLM_HEAD)
 					{
 						olmTile = null;
 					}
@@ -1228,8 +1233,8 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 
 			switch (id)
 			{
-				case NpcID.GREAT_OLM_LEFT_CLAW:
-				case NpcID.GREAT_OLM_LEFT_CLAW_7555:
+				case NpcID.OLM_HAND_LEFT_SPAWNING:
+				case NpcID.OLM_HAND_LEFT:
 					meleeHand = null;
 					if (npc.isDead())
 					{
@@ -1242,8 +1247,8 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 						meleeHandLastRatio = 100;
 					}
 					break;
-				case NpcID.GREAT_OLM_RIGHT_CLAW:
-				case NpcID.GREAT_OLM_RIGHT_CLAW_7553:
+				case NpcID.OLM_HAND_RIGHT_SPAWNING:
+				case NpcID.OLM_HAND_RIGHT:
 					mageHand = null;
 					if (npc.isDead())
 					{
@@ -1256,17 +1261,17 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 						mageHandLastRatio = 100;
 					}
 					break;
-				case NpcID.ICE_DEMON:
+				case NpcID.RAIDS_ICEDEMON_NONCOMBAT:
 					iceDemon = null;
 					break;
-				case NpcID.MUTTADILE_7562: //Baby muttadile
+				case NpcID.RAIDS_DOGODILE_JUNIOR: //Baby muttadile
 					smallMuttaAlive = false;
 					smallMutta = null;
 					lastHealthScale = 0;
 					lastRatio = 0;
 					break;
-				case NpcID.MUTTADILE: //Big muttadile in water
-				case NpcID.MUTTADILE_7563: //Big muttadile
+				case NpcID.RAIDS_DOGODILE_SUBMERGED: //Big muttadile in water
+				case NpcID.RAIDS_DOGODILE: //Big muttadile
 					bigMutta = null;
 					bigMuttaLastHealthScale = 0;
 					bigMuttaLastRatio = 0;
@@ -1279,7 +1284,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 				{
 					olmHead = null;
 					olmSpawned = false;
-					if (id == NpcID.GREAT_OLM)
+					if (id == NpcID.OLM_HEAD_SPAWNING)
 					{
 						olmTile = null;
 					}
@@ -1301,7 +1306,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 			NPC npc = e.getNpc();
 			int id = npc.getId();
 
-			if (id == NpcID.GREAT_OLM_7554)
+			if (id == NpcID.OLM_HEAD)
 			{
 				olmTile = null;
 			}
@@ -1348,11 +1353,12 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 	@Subscribe
 	public void onNpcLootReceived(NpcLootReceived e)
 	{
+		// This no longer works due to pots dropping for everyone
 		if (e.getNpc().getName() != null && e.getNpc().getName().equalsIgnoreCase("vanguard") && inRaid && client.getLocalPlayer() != null)
 		{
 			for (ItemStack item : e.getItems())
 			{
-				if (item.getId() == ItemID.OVERLOAD_4_20996)
+				if (item.getId() == ItemID.RAIDS_VIAL_OVERLOAD_STRONG_4)
 				{
 					if (partyService.isInParty())
 					{
@@ -1440,9 +1446,10 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 	@Subscribe
 	public void onClientTick(ClientTick e)
 	{
+		Menu menu = client.getMenu();
 		if (client.getGameState() == GameState.LOGGED_IN && !client.isMenuOpen())
 		{
-			MenuEntry[] menuEntries = client.getMenuEntries();
+			MenuEntry[] menuEntries = menu.getMenuEntries();
 			int idx = 0;
 			optionIndexes.clear();
 
@@ -1458,7 +1465,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 				swapMenuEntry(idx++, entry);
 			}
 		}
-		client.setMenuEntries(updateMenuEntries(client.getMenuEntries()));
+		menu.setMenuEntries(updateMenuEntries(menu.getMenuEntries()));
 	}
 
 	public int getMaxEnhanceCycles()
@@ -1474,7 +1481,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 	@Subscribe
 	public void onVarbitChanged(VarbitChanged e)
 	{
-		inRaid = client.getVarbitValue(Varbits.IN_RAID) == 1;
+		inRaid = client.getVarbitValue(VarbitID.RAIDS_CLIENT_INDUNGEON) == 1;
 
 		if (inRaid)
 		{
@@ -1505,11 +1512,11 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 			}
 			else
 			{
-				if (client.getVarpValue(VarPlayer.HP_HUD_NPC_ID) == 7555)
+				if (client.getVarpValue(VarPlayerID.HPBAR_HUD_NPC) == 7555)
 				{
 					meleeHandHp = client.getVarbitValue(6099);
 				}
-				else if (client.getVarpValue(VarPlayer.HP_HUD_NPC_ID) == 7553)
+				else if (client.getVarpValue(VarPlayerID.HPBAR_HUD_NPC) == 7553)
 				{
 					mageHandHp = client.getVarbitValue(6099);
 				}
@@ -1619,19 +1626,19 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 
 				switch (p.getId())
 				{
-					case 1341: //Mage Orb
+					case SpotanimID.OLM_WEAK_MAGE_PROJ:
 					{
-						newID = 2208; //Warden Blue Orb
+						newID = SpotanimID.TOA_WARDENS_PRAYER_MAGIC_TRAVEL;
 						break;
 					}
-					case 1343: //Range Orb
+					case SpotanimID.OLM_WEAK_RANGE_PROJ:
 					{
-						newID = 2206; //Warden White Arrow
+						newID = SpotanimID.TOA_WARDENS_PRAYER_RANGED_TRAVEL;
 						break;
 					}
-					case 1345: //Melee Orb
+					case SpotanimID.OLM_WEAK_MELEE_PROJ:
 					{
-						newID = 2204; //Warden Red Sword
+						newID = SpotanimID.TOA_WARDENS_PRAYER_MELEE_TRAVEL;
 						break;
 					}
 				}
@@ -1640,14 +1647,16 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 				{
 					Projectile orb = client.createProjectile(
 						newID,
-						p.getFloor(),
-						p.getX1(), p.getY1(),
-						p.getHeight(),
-						p.getStartCycle(), p.getEndCycle(),
+						p.getSourcePoint(),
+						p.getStartHeight(),
+						p.getSourceActor(),
+						p.getTargetPoint(),
+						p.getEndHeight(),
+						p.getTargetActor(),
+						p.getStartCycle(),
+						p.getEndCycle(),
 						p.getSlope(),
-						p.getStartHeight(), p.getEndHeight(),
-						p.getInteracting(),
-						p.getTarget().getX(), p.getTarget().getY());
+						p.getStartPos());
 
 					client.getProjectiles().addLast(orb);
 					p.setEndCycle(0);
@@ -1668,7 +1677,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 
 	private void swap(String optionA, String optionB, String target, int index, boolean strict)
 	{
-		MenuEntry[] menuEntries = client.getMenuEntries();
+		MenuEntry[] menuEntries = client.getMenu().getMenuEntries();
 		int thisIndex = findIndex(menuEntries, index, optionB, target, strict);
 		int optionIdx;
 
@@ -1736,7 +1745,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 			entry2.setType(MenuAction.CC_OP);
 		}
 
-		client.setMenuEntries(entries);
+		client.getMenu().setMenuEntries(entries);
 		optionIndexes.clear();
 		int idx = 0;
 		for (MenuEntry menuEntry : entries)
@@ -1785,7 +1794,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 				if (enhanceInfobox == null && config.detailedPrayerEnhance() != CoxAdditionsConfig.enhanceMode.OFF)
 				{
 					enhanceInfobox = new EnhanceInfobox(client, this, config);
-					img = ItemID.PRAYER_ENHANCE_4_20972;
+					img = ItemID.RAIDS_VIAL_PRAYER_STRONG_4;
 					enhanceInfobox.setImage(itemManager.getImage(img));
 					infoBoxManager.addInfoBox(enhanceInfobox);
 				}
@@ -1797,7 +1806,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 						(config.grubsInfobox() == CoxAdditionsConfig.grubsMode.BOTH && (inThieving || inPrep)))
 					{
 						grubsInfobox = new GrubsInfobox(client, this, config);
-						img = ItemID.CAVERN_GRUBS;
+						img = ItemID.RAIDS_THIEVINGCHEST_GRUBS;
 						grubsInfobox.setImage(itemManager.getImage(img));
 						infoBoxManager.addInfoBox(grubsInfobox);
 					}
@@ -1827,7 +1836,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 	{
 		if (client.getGameState() == GameState.LOGGED_IN && inRaid)
 		{
-			int chunkData = client.getInstanceTemplateChunks()[z][x / 8][y / 8];
+			int chunkData = client.getTopLevelWorldView().getInstanceTemplateChunks()[z][x / 8][y / 8];
 			return InstanceTemplates.findMatch(chunkData);
 		}
 		return null;
@@ -1836,7 +1845,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 	public InstanceTemplates room()
 	{
 		return getCurrentRoom(client.getLocalPlayer().getLocalLocation().getSceneX(),
-			client.getLocalPlayer().getLocalLocation().getSceneY(), client.getPlane());
+			client.getLocalPlayer().getLocalLocation().getSceneY(), client.getTopLevelWorldView().getPlane());
 	}
 
 	public void loadFont(boolean overlay)
@@ -1855,7 +1864,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 					overlayFont = FontManager.getRunescapeBoldFont();
 					break;
 				case CUSTOM:
-					if (!config.overlayFontName().equals(""))
+					if (!config.overlayFontName().isEmpty())
 					{
 						overlayFont = new Font(config.overlayFontName(), config.overlayFontWeight().getWeight(), config.overlayFontSize());
 					}
@@ -1876,7 +1885,7 @@ public class CoxAdditionsPlugin extends Plugin implements KeyListener
 					panelFont = FontManager.getRunescapeBoldFont();
 					break;
 				case CUSTOM:
-					if (!config.panelFontName().equals(""))
+					if (!config.panelFontName().isEmpty())
 					{
 						panelFont = new Font(config.panelFontName(), config.panelFontWeight().getWeight(), config.panelFontSize());
 					}

--- a/src/main/java/com/coxadditions/overlay/CoxAdditionsOverlay.java
+++ b/src/main/java/com/coxadditions/overlay/CoxAdditionsOverlay.java
@@ -31,6 +31,8 @@ import com.coxadditions.CoxAdditionsPlugin;
 import java.awt.geom.Point2D;
 import net.runelite.api.Point;
 import net.runelite.api.*;
+import net.runelite.api.gameval.ObjectID;
+import net.runelite.api.gameval.VarPlayerID;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.*;
@@ -58,7 +60,7 @@ public class CoxAdditionsOverlay extends Overlay
 		this.config = config;
 		this.modelOutlineRenderer = modelOutlineRenderer;
 		setPosition(OverlayPosition.DYNAMIC);
-		setPriority(OverlayPriority.HIGH);
+		setPriority(PRIORITY_HIGH);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 	}
 
@@ -160,9 +162,10 @@ public class CoxAdditionsOverlay extends Overlay
 				}
 			}
 
-			if (!config.tlList().equals(""))
+			if (!config.tlList().isEmpty())
 			{
-				for (NPC npc : client.getNpcs())
+				WorldView worldView = client.getTopLevelWorldView();
+				for (NPC npc : worldView.npcs())
 				{
 					if (npc.getName() != null && npc.getId() != 8203)
 					{
@@ -185,10 +188,10 @@ public class CoxAdditionsOverlay extends Overlay
 						{
 							NPCComposition comp = npc.getComposition();
 							int size = comp.getSize();
-							LocalPoint lp = LocalPoint.fromWorld(client, npc.getWorldLocation());
+							LocalPoint lp = LocalPoint.fromWorld(worldView, npc.getWorldLocation());
 							if (lp != null)
 							{
-								lp = new LocalPoint(lp.getX() + size * 128 / 2 - 64, lp.getY() + size * 128 / 2 - 64);
+								lp = new LocalPoint(lp.getX() + size * 128 / 2 - 64, lp.getY() + size * 128 / 2 - 64, worldView);
 								Polygon tilePoly = Perspective.getCanvasTileAreaPoly(client, lp, size);
 								switch (config.tileLines())
 								{
@@ -255,12 +258,13 @@ public class CoxAdditionsOverlay extends Overlay
 			if (plugin.room() == InstanceTemplates.RAIDS_THIEVING && client.getLocalPlayer() != null
 				&& WorldPoint.fromLocalInstance(client, client.getLocalPlayer().getLocalLocation()).getRegionID() == 13140)
 			{
-				Tile[][][] tiles = client.getScene().getTiles();
+				WorldView worldView = client.getTopLevelWorldView();
+				Tile[][][] tiles = worldView.getScene().getTiles();
 				for (int x = 0; x < Constants.SCENE_SIZE; ++x)
 				{
 					for (int y = 0; y < Constants.SCENE_SIZE; ++y)
 					{
-						Tile tile = tiles[client.getPlane()][x][y];
+						Tile tile = tiles[worldView.getPlane()][x][y];
 						if (tile != null && tile.getGameObjects() != null)
 						{
 							checkObjects:
@@ -315,21 +319,22 @@ public class CoxAdditionsOverlay extends Overlay
 			//Made by De0
 			if (config.ccWarning())
 			{
-				int sceneX = 1232 - client.getBaseX(), sceneY = 3573 - client.getBaseY();
+				WorldView worldView = client.getTopLevelWorldView();
+				int sceneX = 1232 - worldView.getBaseX(), sceneY = 3573 - worldView.getBaseY();
 				if (sceneX >= 0 && sceneY >= 0 && sceneX < 104 && sceneY < 104)
 				{
-					Tile tile = client.getScene().getTiles()[0][sceneX][sceneY];
+					Tile tile = worldView.getScene().getTiles()[0][sceneX][sceneY];
 					if (tile.getGameObjects()[0] != null)
 					{
 						GameObject obj = tile.getGameObjects()[0];
-						if (obj.getId() == ObjectID.CHAMBERS_OF_XERIC)
+						if (obj.getId() == ObjectID.RAIDS_ENTRANCE_STEPS)
 						{
 							Color color = null;
 							if (client.getFriendsChatManager() == null)
 							{
 								color = new Color(255, 0, 0, 50);
 							}
-							else if (client.getVarpValue(VarPlayer.IN_RAID_PARTY) == -1)
+							else if (client.getVarpValue(VarPlayerID.RAIDS_PARTY_GROUPHOLDER) == -1)
 							{
 								color = new Color(200, 200, 0, 50);
 							}

--- a/src/main/java/com/coxadditions/overlay/CoxAdditionsOverlay.java
+++ b/src/main/java/com/coxadditions/overlay/CoxAdditionsOverlay.java
@@ -145,7 +145,9 @@ public class CoxAdditionsOverlay extends Overlay
 				}
 			}
 
-			if (config.instanceTimer() == CoxAdditionsConfig.instanceTimerMode.OVERHEAD && plugin.isInstanceTimerRunning())
+			if ((config.instanceTimer() == CoxAdditionsConfig.instanceTimerMode.OVERHEAD
+				|| config.instanceTimer() == CoxAdditionsConfig.instanceTimerMode.BOTH)
+				&& plugin.isInstanceTimerRunning())
 			{
 				Player player = client.getLocalPlayer();
 				if (player != null)

--- a/src/main/java/com/coxadditions/overlay/CoxHPOverlay.java
+++ b/src/main/java/com/coxadditions/overlay/CoxHPOverlay.java
@@ -12,11 +12,9 @@ import net.runelite.api.Client;
 import net.runelite.api.InstanceTemplates;
 import net.runelite.api.NPC;
 import net.runelite.api.Point;
-import net.runelite.api.Varbits;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
 
 public class CoxHPOverlay extends Overlay
@@ -32,7 +30,7 @@ public class CoxHPOverlay extends Overlay
 		this.plugin = plugin;
 		this.config = config;
 		setPosition(OverlayPosition.DYNAMIC);
-		setPriority(OverlayPriority.HIGH);
+		setPriority(PRIORITY_HIGH);
 		setLayer(OverlayLayer.UNDER_WIDGETS);
 	}
 

--- a/src/main/java/com/coxadditions/overlay/CoxItemOverlay.java
+++ b/src/main/java/com/coxadditions/overlay/CoxItemOverlay.java
@@ -34,8 +34,8 @@ public class CoxItemOverlay extends WidgetItemOverlay
 	public void renderItemOverlay(Graphics2D graphics, int itemId, WidgetItem itemWidget)
 	{
 		if (plugin.isInRaid() && config.highlightChest() != CoxAdditionsConfig.HighlightChestMode.OFF
-			&& ((!config.highlightChestItems().equals("") && plugin.getChestHighlightIdList().size() > 0)
-			|| (!config.highlightChestItems2().equals("") && plugin.getChestHighlightIdList2().size() > 0)))
+			&& ((!config.highlightChestItems().isEmpty() && !plugin.getChestHighlightIdList().isEmpty())
+			|| (!config.highlightChestItems2().isEmpty() && !plugin.getChestHighlightIdList2().isEmpty())))
 		{
 			if (plugin.getChestHighlightIdList().contains(String.valueOf(itemId)) || itemNameInList(plugin.getChestHighlightIdList(), itemWidget))
 			{

--- a/src/main/java/com/coxadditions/overlay/CoxPrepOverlay.java
+++ b/src/main/java/com/coxadditions/overlay/CoxPrepOverlay.java
@@ -11,7 +11,6 @@ import net.runelite.api.InstanceTemplates;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.LayoutableRenderableEntity;
 import net.runelite.client.ui.overlay.components.LineComponent;
 
@@ -26,7 +25,7 @@ public class CoxPrepOverlay extends OverlayPanel
 		this.plugin = plugin;
 		this.config = config;
 		setPosition(OverlayPosition.TOP_LEFT);
-		setPriority(OverlayPriority.HIGH);
+		setPriority(PRIORITY_HIGH);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 	}
 

--- a/src/main/java/com/coxadditions/overlay/InstanceTimerOverlay.java
+++ b/src/main/java/com/coxadditions/overlay/InstanceTimerOverlay.java
@@ -34,7 +34,10 @@ public class InstanceTimerOverlay extends OverlayPanel
 		}
 
 		panelComponent.getChildren().clear();
-		if (config.instanceTimer() == CoxAdditionsConfig.instanceTimerMode.INFOBOX && plugin.isInstanceTimerRunning() && plugin.isInRaid())
+		if ((config.instanceTimer() == CoxAdditionsConfig.instanceTimerMode.INFOBOX
+			|| config.instanceTimer() == CoxAdditionsConfig.instanceTimerMode.BOTH)
+			&& plugin.isInstanceTimerRunning()
+			&& plugin.isInRaid())
 		{
 			Color goodTick = new Color(37, 197, 79);
 			Color badTick = new Color(224, 60, 49);

--- a/src/main/java/com/coxadditions/overlay/OlmPhasePanel.java
+++ b/src/main/java/com/coxadditions/overlay/OlmPhasePanel.java
@@ -7,7 +7,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.Varbits;
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.components.TitleComponent;
 
@@ -34,7 +34,7 @@ public class OlmPhasePanel extends OverlayPanel
 		}
 
 		panelComponent.getChildren().clear();
-		if (config.olmPhasePanel() && this.client.getVarbitValue(Varbits.IN_RAID) == 1 && !plugin.getOlmPhase().equals(""))
+		if (config.olmPhasePanel() && this.client.getVarbitValue(VarbitID.RAIDS_CLIENT_INDUNGEON) == 1 && !plugin.getOlmPhase().isEmpty())
 		{
 			graphics.setFont(plugin.getPanelFont());
 			Color color = plugin.getOlmPhase().equals("Acid") ? Color.GREEN : plugin.getOlmPhase().equals("Flame") ? Color.RED : Color.MAGENTA;

--- a/src/main/java/com/coxadditions/overlay/OlmSideOverlay.java
+++ b/src/main/java/com/coxadditions/overlay/OlmSideOverlay.java
@@ -15,7 +15,6 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.util.ColorUtil;
 
 public class OlmSideOverlay extends Overlay
@@ -31,7 +30,7 @@ public class OlmSideOverlay extends Overlay
 		this.plugin = plugin;
 		this.config = config;
 		setPosition(OverlayPosition.DYNAMIC);
-		setPriority(OverlayPriority.LOW);
+		setPriority(PRIORITY_LOW);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 	}
 

--- a/src/main/java/com/coxadditions/overlay/RaidsPotsStatusOverlay.java
+++ b/src/main/java/com/coxadditions/overlay/RaidsPotsStatusOverlay.java
@@ -11,7 +11,7 @@ import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import javax.inject.Inject;
 import net.runelite.api.Client;
-import net.runelite.api.ItemID;
+import net.runelite.api.gameval.ItemID;
 import net.runelite.api.Perspective;
 import net.runelite.api.Player;
 import net.runelite.api.Point;
@@ -19,7 +19,6 @@ import net.runelite.client.game.ItemManager;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.util.ImageUtil;
 
@@ -41,7 +40,7 @@ public class RaidsPotsStatusOverlay extends Overlay
 		this.itemManager = itemManager;
 
 		setPosition(OverlayPosition.DYNAMIC);
-		setPriority(OverlayPriority.HIGH);
+		setPriority(PRIORITY_HIGH);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 	}
 
@@ -52,7 +51,7 @@ public class RaidsPotsStatusOverlay extends Overlay
 		{
 			for (RaidsPlayers raider : plugin.getPlayersInParty())
 			{
-				for (Player player : client.getPlayers())
+				for (Player player : client.getTopLevelWorldView().players())
 				{
 					if (player.getName() != null && player.getName().equals(raider.getPlayer()))
 					{
@@ -115,8 +114,8 @@ public class RaidsPotsStatusOverlay extends Overlay
 				zOffset = player.getLogicalHeight() + 250;
 		}
 
-		Point base = Perspective.localToCanvas(client, player.getLocalLocation(), client.getPlane(), zOffset);
-		BufferedImage image = pot.equals("OVL") ? itemManager.getImage(ItemID.OVERLOAD_4_20996) : itemManager.getImage(ItemID.PRAYER_ENHANCE_4);
+		Point base = Perspective.localToCanvas(client, player.getLocalLocation(), client.getTopLevelWorldView().getPlane(), zOffset);
+		BufferedImage image = pot.equals("OVL") ? itemManager.getImage(ItemID.RAIDS_VIAL_OVERLOAD_STRONG_4) : itemManager.getImage(ItemID.RAIDS_VIAL_PRAYER_STRONG_4);
 		image = ImageUtil.resizeImage(image, size, size);
 
 		if (base != null)

--- a/src/main/java/com/coxadditions/overlay/VangPotsOverlay.java
+++ b/src/main/java/com/coxadditions/overlay/VangPotsOverlay.java
@@ -11,7 +11,6 @@ import net.runelite.api.InstanceTemplates;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.LineComponent;
 
 public class VangPotsOverlay extends OverlayPanel
@@ -30,7 +29,7 @@ public class VangPotsOverlay extends OverlayPanel
 		this.plugin = plugin;
 		this.config = config;
 		setPosition(OverlayPosition.TOP_LEFT);
-		setPriority(OverlayPriority.MED);
+		setPriority(PRIORITY_MED);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 	}
 

--- a/src/main/java/com/coxadditions/overlay/VanguardInfoBox.java
+++ b/src/main/java/com/coxadditions/overlay/VanguardInfoBox.java
@@ -10,7 +10,6 @@ import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayPriority;
 import net.runelite.client.ui.overlay.components.LineComponent;
 import net.runelite.client.ui.overlay.components.PanelComponent;
 import net.runelite.client.ui.overlay.components.TitleComponent;
@@ -26,7 +25,7 @@ public class VanguardInfoBox extends Overlay
 	{
 		super(plugin);
 		setPosition(OverlayPosition.TOP_LEFT);
-		setPriority(OverlayPriority.HIGH);
+		setPriority(PRIORITY_HIGH);
 		this.plugin = plugin;
 		this.config = config;
 	}

--- a/src/main/java/com/coxadditions/party/PartyInstanceTimerSync.java
+++ b/src/main/java/com/coxadditions/party/PartyInstanceTimerSync.java
@@ -1,0 +1,15 @@
+package com.coxadditions.party;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import net.runelite.client.party.messages.PartyMemberMessage;
+
+@Value
+@AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class PartyInstanceTimerSync extends PartyMemberMessage
+{
+	int playerID;
+	int instanceTimerValue;
+}


### PR DESCRIPTION
Add the ability to sync the instance timer between the raid leader and other RL Party members who weren't present when the raid instance was created.
Add the ability to keep the instance timer on during the raid.
Add "both" option to instance timer overlay styles.
Add few more checks to more reliably reset the instance timer when needed.